### PR TITLE
Feat: 페이지 레이아웃 모바일 웹 사이즈 기준으로 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import Gnb from "@/components/commons/Gnb";
 
 export const metadata: Metadata = {
   title: {
@@ -24,8 +25,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={`${pretendard.variable} font-pretendard min-h-screen flex flex-col items-center`}>
-        {children}
+      <body className={`${pretendard.variable} font-pretendard bg-[#f5f5f5] min-w-screen flex flex-col items-center`}>
+        <main className="w-screen sm:w-[600px] bg-white min-h-screen shadow-xl">{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,8 @@ import Gnb from "@/components/commons/Gnb";
 export default function Home() {
   return (
     <>
-      <h1>Home page</h1>
       <Gnb />
+      <h1>Home page</h1>
     </>
   );
 }

--- a/src/app/study/[id]/dashboard/page.tsx
+++ b/src/app/study/[id]/dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function Dashboard() {
+  return (
+    <>
+      <h1>Dashboard Page</h1>
+    </>
+  );
+}

--- a/src/app/study/[id]/layout.tsx
+++ b/src/app/study/[id]/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export default function layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/study/[id]/page.tsx
+++ b/src/app/study/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function StudyDetail() {
+  return (
+    <>
+      <h1>StudyDetail</h1>
+    </>
+  );
+}

--- a/src/components/commons/Gnb.tsx
+++ b/src/components/commons/Gnb.tsx
@@ -13,7 +13,7 @@ export default function Gnb() {
   const [sideBar, setSideBar, handleSideBar] = useToggle(false);
 
   return (
-    <div className="sticky top-0 bg-white w-[375px] h-[54px] flex justify-between items-center px-4 border-b border-gray-300">
+    <div className="sticky top-0 bg-white w-full h-[54px] flex justify-between items-center px-4 border-b border-gray-300">
       <div className="flex justify-center items-center gap-2">
         <button onClick={handleSideBar}>
           <Image src="icons/menu.svg" alt="menu 아이콘" width={24} height={24} />


### PR DESCRIPTION
## 작업 주제

- [x] UI추가
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 스크린샷

https://github.com/sturing-fourten/sturing/assets/148737398/d10d0473-18a3-4343-b870-31308a318ace

## 구현 사항 설명

페이지 레이아웃 모바일 웹 사이즈 기준으로 적용
일단 데스크탑, 태블릿에선 width 600px 로 고정되도록 했습니다. (강남언니 사이즈 참고)

대시보드(내 스터디 상세) 페이지가 스터디 폴더에 같이 있어서 폴더 만들어서 올렸어요!