### PR TITLE
Feat: 스터디 , 강의 상세 api 리팩토링 및 스터디 상태 변경 (모집완료/시작/종료) api 구현, 강의 상세페이지 api 연결 리팩토링

### DIFF
--- a/src/app/api/lecture/[id]/route.ts
+++ b/src/app/api/lecture/[id]/route.ts
@@ -1,16 +1,21 @@
 import connectDB from "@/lib/database/db";
 import { Lecture } from "@/schema/lectureSchema";
+import { Study } from "@/schema/studySchema";
 
-export async function GET({ params }: { params: { id: string } }) {
+export async function GET(req: Request, { params }: { params: { id: string } }) {
   const id = params.id;
 
   try {
     await connectDB();
     const lecture = await Lecture.findById(id);
-    return Response.json({ lecture });
+    if (!lecture) {
+      return Response.json({ message: "해당 강의가 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const relatedStudyList = await Study.find({ lectureId: id, status: "RECRUIT_START" });
+
+    return Response.json({ lecture, relatedStudyList });
   } catch (error: any) {
-    return new Response(JSON.stringify({ error: "강의를 불러오는데 실패하였습니다." }), {
-      status: 500,
-    });
+    return Response.json({ message: "강의를 불러오는데 실패하였습니다." }, { status: 500 });
   }
 }

--- a/src/app/api/my-study/[id]/done/route.ts
+++ b/src/app/api/my-study/[id]/done/route.ts
@@ -1,0 +1,51 @@
+import connectDB from "@/lib/database/db";
+import { Study } from "@/schema/studySchema";
+import { User } from "@/schema/userSchema";
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const studyId = params.id;
+  const { userId } = await req.json();
+  connectDB();
+
+  if (!studyId) {
+    return Response.json({ error: "스터디 id 가 필요합니다." }, { status: 400 });
+  }
+  if (!userId) {
+    return Response.json({ error: "유저 id 가 필요합니다." }, { status: 400 });
+  }
+  connectDB();
+  try {
+    const currentStudy = await Study.findById(studyId);
+
+    if (!currentStudy) {
+      return Response.json({ message: "스터디가 존재하지 않습니다" }, { status: 404 });
+    }
+
+    const currentStudyOwnerId = currentStudy.ownerId.toString();
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return Response.json({ message: "유저가 존재하지 않습니다" }, { status: 404 });
+    }
+
+    if (currentStudyOwnerId !== user.id) {
+      return Response.json({ message: "권한이 없습니다" }, { status: 403 });
+    }
+
+    const isAlreadyDone = await Study.findOne({ _id: studyId, status: "DONE" });
+
+    if (isAlreadyDone) {
+      return Response.json({ message: "이미 완료된 스터디입니다." }, { status: 400 });
+    }
+
+    await Study.updateOne({ _id: studyId }, { status: "DONE" });
+
+    return Response.json({ message: "스터디가 완료 되었습니다." }, { status: 200 });
+  } catch (error: any) {
+    if (error.name === "CastError") {
+      return Response.json({ message: "요청을 처리할 수 없습니다." }, { status: 404 });
+    } else {
+      return Response.json({ message: error.name }, { status: 500 });
+    }
+  }
+}

--- a/src/app/api/my-study/[id]/recruit-end/route.ts
+++ b/src/app/api/my-study/[id]/recruit-end/route.ts
@@ -1,0 +1,52 @@
+import connectDB from "@/lib/database/db";
+import { Study } from "@/schema/studySchema";
+import { User } from "@/schema/userSchema";
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const studyId = params.id;
+  const { userId } = await req.json();
+
+  if (!studyId) {
+    return Response.json({ error: "스터디 id 가 필요합니다." }, { status: 400 });
+  }
+  if (!userId) {
+    return Response.json({ error: "유저 id 가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    await connectDB();
+    const currentStudy = await Study.findById(studyId);
+
+    if (!currentStudy) {
+      return Response.json({ message: "스터디가 존재하지 않습니다" }, { status: 404 });
+    }
+
+    const currentStudyOwnerId = currentStudy.ownerId.toString();
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return Response.json({ message: "유저가 존재하지 않습니다" }, { status: 404 });
+    }
+
+    if (currentStudyOwnerId !== user.id) {
+      return Response.json({ message: "권한이 없습니다" }, { status: 403 });
+    }
+
+    const isAlreadyRecruitEnd = await Study.findOne({ _id: studyId, status: "RECRUIT_END" });
+
+    if (isAlreadyRecruitEnd) {
+      return Response.json({ message: "이미 모집 완료된 스터디입니다." }, { status: 400 });
+    }
+
+    await Study.updateOne({ _id: studyId }, { status: "RECRUIT_END" });
+
+    return Response.json({ message: "스터디 모집이 완료 되었습니다." }, { status: 200 });
+  } catch (error: any) {
+    console.log(error.name);
+    if (error.name === "CastError") {
+      return Response.json({ message: "요청을 처리할 수 없습니다." }, { status: 404 });
+    } else {
+      return Response.json({ message: error.name }, { status: 500 });
+    }
+  }
+}

--- a/src/app/api/my-study/[id]/start/route.ts
+++ b/src/app/api/my-study/[id]/start/route.ts
@@ -1,0 +1,52 @@
+import connectDB from "@/lib/database/db";
+import { Study } from "@/schema/studySchema";
+import { User } from "@/schema/userSchema";
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const studyId = params.id;
+  const { userId } = await req.json();
+
+  if (!studyId) {
+    return Response.json({ error: "스터디 id 가 필요합니다." }, { status: 400 });
+  }
+  if (!userId) {
+    return Response.json({ error: "유저 id 가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    await connectDB();
+    const currentStudy = await Study.findById(studyId);
+
+    if (!currentStudy) {
+      return Response.json({ message: "스터디가 존재하지 않습니다" }, { status: 404 });
+    }
+
+    const currentStudyOwnerId = currentStudy.ownerId.toString();
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return Response.json({ message: "유저가 존재하지 않습니다" }, { status: 404 });
+    }
+
+    if (currentStudyOwnerId !== user.id) {
+      return Response.json({ message: "권한이 없습니다" }, { status: 403 });
+    }
+
+    const isAlreadyRecruitEnd = await Study.findOne({ _id: studyId, status: "PROGRESS" });
+
+    if (isAlreadyRecruitEnd) {
+      return Response.json({ message: "이미 진행중인 스터디입니다." }, { status: 400 });
+    }
+
+    await Study.updateOne({ _id: studyId }, { status: "PROGRESS" });
+
+    return Response.json({ message: "스터디가 시작 되었습니다." }, { status: 200 });
+  } catch (error: any) {
+    console.log(error.name);
+    if (error.name === "CastError") {
+      return Response.json({ message: "요청을 처리할 수 없습니다." }, { status: 404 });
+    } else {
+      return Response.json({ message: error.name }, { status: 500 });
+    }
+  }
+}

--- a/src/app/api/study/[id]/route.ts
+++ b/src/app/api/study/[id]/route.ts
@@ -1,4 +1,6 @@
 import connectDB from "@/lib/database/db";
+import { RecruitComment } from "@/schema/RecruitCommentSchema";
+import { Lecture } from "@/schema/lectureSchema";
 import { Study } from "@/schema/studySchema";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
@@ -10,8 +12,15 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 
   try {
     const study = await Study.findById(studyId);
+    if (!study) {
+      return Response.json({ message: "스터디가 존재하지 않습니다." }, { status: 404 });
+    }
 
-    return Response.json(study);
+    const lectureId = study.lectureId;
+    const lectureData = await Lecture.findById(lectureId);
+    const { _id, category, online, platform, rating, title, instructor } = lectureData;
+    const lectureResult = { id: _id, category, online, platform, rating, title, instructor };
+    return Response.json({ study, lecture: lectureResult }, { status: 200 });
   } catch (error: any) {
     if (error.name === "CastError") {
       return Response.json({ message: "스터디가 존재하지 않습니다." }, { status: 404 });
@@ -28,6 +37,10 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
   }
   connectDB();
   try {
+    const study = await Study.findById(studyId);
+    if (!study) {
+      return Response.json({ message: "스터디가 존재하지 않습니다." }, { status: 404 });
+    }
     await Study.findByIdAndDelete(studyId);
 
     return Response.json({ message: "스터디가 삭제되었습니다." }, { status: 200 });

--- a/src/app/api/study/route.ts
+++ b/src/app/api/study/route.ts
@@ -1,4 +1,5 @@
 import connectDB from "@/lib/database/db";
+import { Lecture } from "@/schema/lectureSchema";
 import { Study } from "@/schema/studySchema";
 import { TeamMembers } from "@/schema/teamMemberSchema";
 
@@ -33,7 +34,15 @@ export async function POST(request: Request) {
 
     // 3) Study에 teamMembersId 추가
     await Study.findOneAndUpdate({ _id: newStudyId }, { $push: { teamMembersId: teamMembersId } }, { new: true });
-    return Response.json(newStudyResult, { status: 200 });
+
+    // 4) Study에 관련 강의 추가
+    const lectureId = newStudyResult.lectureId;
+    const lectureData = await Lecture.findById(lectureId);
+
+    const { _id, category, online, platform, rating, title, instructor } = lectureData;
+    const lectureResult = { id: _id, category, online, platform, rating, title, instructor };
+
+    return Response.json({ study: newStudyResult, lecture: lectureResult }, { status: 200 });
   } catch (error: any) {
     if (error.name === "ValidationError") {
       return Response.json({ message: "필수 값을 모두 입력해주세요" }, { status: 400 });

--- a/src/app/lecture/[id]/page.tsx
+++ b/src/app/lecture/[id]/page.tsx
@@ -3,38 +3,18 @@ import Header from "@/components/domains/detail/Header";
 import Contents from "@/components/domains/detail/lecture/Contents";
 import { getLectureAction } from "@/lib/database/action/lecture";
 
-export interface LectureData {
-  _id: string;
-  online: boolean;
-  category: string;
-  platform: string;
-  rating: number;
-  link: string;
-  title: string;
-  instructor: string;
-  level: string;
-  tag: string[];
-  lectureStudyList: any[];
-  review: {
-    reviewerId: string;
-    reviewer: string;
-    rating: number;
-    comment: string;
-    created_at: string;
-    _id: string;
-  }[];
-}
-
 export default async function LectureDetail({ params }: { params: { id: string } }) {
   const { id } = params;
   const lectureData = await getLectureAction(id);
-  const lectureId = lectureData._id.toString();
+
+  const lectureId = lectureData.lecture?._id;
+  if (!lectureId) return <div>강의를 찾을 수 없습니다</div>; //에러처리 필요
 
   return (
     <>
       <div className="flex-col inline-flex w-full h-dvh">
         <div className="flex-1 overflow-auto scrollbar-hide">
-          <Header page="lecture" lectureData={lectureData} />
+          <Header page="lecture" lectureInfo={lectureData.lecture} />
           <Contents lectureData={lectureData} />
         </div>
         <FixedBottomBar page="lecture" lectureId={lectureId} />

--- a/src/components/domains/detail/DetailInfo.tsx
+++ b/src/components/domains/detail/DetailInfo.tsx
@@ -11,7 +11,7 @@ export default function DetailInfo({ icon, title, content, isWhite = false }: De
   return (
     <>
       <li
-        className={`list-none flex items-center gap-[11px] text-[14px] font-medium  leading-[150%] ${
+        className={`list-none flex items-start gap-[11px] text-[14px] font-medium  leading-[150%] ${
           isWhite ? "text-white" : "text-gray-800"
         }`}>
         <div className="flex items-center w-[62px] gap-[7px]">

--- a/src/components/domains/detail/Header.tsx
+++ b/src/components/domains/detail/Header.tsx
@@ -1,4 +1,3 @@
-import { LectureData } from "@/app/lecture/[id]/page";
 import LectureLinkBanner from "@/components/commons/LectureLinkBanner";
 import TopBar from "@/components/commons/TopBar";
 import { TagLight } from "@/components/commons/tag/TagLight";
@@ -6,19 +5,21 @@ import { TagMain } from "@/components/commons/tag/TagMain";
 import { TagRate } from "@/components/commons/tag/TagRate";
 import { IMAGES_DEFAUlT } from "@/constant/images";
 import { CATEGORY } from "@/constant/category";
+import { TLectureInfoData } from "@/types/api/lecture";
 
 interface BannerProps {
   page: "study" | "lecture";
-  lectureData: LectureData;
+  lectureInfo: TLectureInfoData;
 }
 
 const { study, lecture } = IMAGES_DEFAUlT;
 
-export default function Header({ page, lectureData }: BannerProps) {
-  const { online, platform, category, rating, title, link } = lectureData;
-  const imageUrl = "";
+export default function Header({ page, lectureInfo }: BannerProps) {
+  const { online, platform, category, rating, title, link } = lectureInfo;
+  const studyImageUrl = ""; //임시
   const isStudy = page === "study";
   const defaultImageUrl = isStudy ? study.src : lecture.src;
+  const imageUrl = isStudy ? studyImageUrl : "";
   const style = {
     backgroundImage: `url(${imageUrl || defaultImageUrl})`,
   };

--- a/src/components/domains/detail/lecture/Contents.tsx
+++ b/src/components/domains/detail/lecture/Contents.tsx
@@ -1,15 +1,16 @@
 import TabMenuLinkUnderlined from "@/components/commons/TabMenuLinkUnderlined";
-
 import LectureInfo from "./LectureInfo";
 import LectureRatings from "./LectureRatings";
 import LectureRelatedStudies from "./LectureRelatedStudies";
-import { LectureData } from "@/app/lecture/[id]/page";
+import { TLectureDetailData } from "@/types/api/lecture";
 
 interface ContentsProps {
-  lectureData: LectureData;
+  lectureData: TLectureDetailData;
 }
 
 export default function Contents({ lectureData }: ContentsProps) {
+  const { lecture, relatedStudyList } = lectureData;
+
   return (
     <div className="mb-[73px]">
       <nav className="flex justify-between items-center gap-3 bg-white sticky top-0 left-0 z-sticky">
@@ -18,9 +19,9 @@ export default function Contents({ lectureData }: ContentsProps) {
         <TabMenuLinkUnderlined title="평점" isCurrent={false} href="#rating" />
       </nav>
       <div className="px-4 sm:overflow-y-auto">
-        <LectureInfo lectureData={lectureData} />
-        <LectureRelatedStudies lectureData={lectureData} />
-        <LectureRatings lectureData={lectureData} />
+        <LectureInfo lectureInfo={lecture} />
+        <LectureRelatedStudies relatedStudyList={relatedStudyList} />
+        <LectureRatings lectureInfo={lecture} />
       </div>
     </div>
   );

--- a/src/components/domains/detail/lecture/LectureInfo.tsx
+++ b/src/components/domains/detail/lecture/LectureInfo.tsx
@@ -1,24 +1,24 @@
-import { LectureData } from "@/app/lecture/[id]/page";
+import { TLectureInfoData } from "@/types/api/lecture";
 import DetailInfo from "../DetailInfo";
 import HashTag from "./elements/HashTag";
 import { LECTURE_INFO } from "@/constant/lecture";
 
 interface LectureInfoProps {
-  lectureData: LectureData;
+  lectureInfo: TLectureInfoData;
 }
 
 const { instructor, level } = LECTURE_INFO;
 
-export default function LectureInfo({ lectureData }: LectureInfoProps) {
+export default function LectureInfo({ lectureInfo }: LectureInfoProps) {
   return (
     <>
       <section className="pt-7 pb-10" id="lectureInfo">
         <div className="flex flex-col gap-3 justify-start">
-          <DetailInfo icon={instructor.icon} title={instructor.title} content={lectureData?.instructor} />
-          <DetailInfo icon={level.icon} title={level.title} content={lectureData?.level} />
+          <DetailInfo icon={instructor.icon} title={instructor.title} content={lectureInfo?.instructor} />
+          <DetailInfo icon={level.icon} title={level.title} content={lectureInfo?.level} />
         </div>
         <div className="flex items-center gap-[14px] mt-5">
-          {lectureData?.tag.map((tag: string, index: number) => (
+          {lectureInfo?.tag.map((tag: string, index: number) => (
             <HashTag key={index} tag={tag} />
           ))}
         </div>

--- a/src/components/domains/detail/lecture/LectureRatings.tsx
+++ b/src/components/domains/detail/lecture/LectureRatings.tsx
@@ -4,14 +4,14 @@ import { TagRate } from "@/components/commons/tag/TagRate";
 import Link from "next/link";
 import Image from "next/image";
 import Title from "../Title";
-import { LectureData } from "@/app/lecture/[id]/page";
+import { TLectureInfoData } from "@/types/api/lecture";
 
 interface LectureRatingsProps {
-  lectureData: LectureData;
+  lectureInfo: TLectureInfoData;
 }
 
-export default function LectureRatings({ lectureData }: LectureRatingsProps) {
-  const { rating, review } = lectureData;
+export default function LectureRatings({ lectureInfo }: LectureRatingsProps) {
+  const { rating, review } = lectureInfo;
   return (
     <>
       <section id="rating">

--- a/src/components/domains/detail/lecture/LectureRelatedStudies.tsx
+++ b/src/components/domains/detail/lecture/LectureRelatedStudies.tsx
@@ -2,29 +2,30 @@ import Button from "@/components/commons/Button";
 import { StudyRecruitCard } from "../../../commons/card/StudyRecruitCard";
 import CardList from "../../../commons/CardList";
 import Title from "../Title";
-import { LectureData } from "@/app/lecture/[id]/page";
+import { TRelatedStudy } from "@/types/api/lecture";
 
 interface LectureRelatedStudiesProps {
-  lectureData: LectureData;
+  relatedStudyList: TRelatedStudy[];
 }
 
-export default function LectureRelatedStudies({ lectureData }: LectureRelatedStudiesProps) {
+export default function LectureRelatedStudies({ relatedStudyList }: LectureRelatedStudiesProps) {
   return (
     <>
-      <section className="mb-[50px]" id="related_study">
-        <Title addStyle="mb-5">
-          이 강의를 수강하는 스터디 <span className="text-main-500 ">10개</span>
-        </Title>
-        <CardList>
-          <StudyRecruitCard isMini isScraped />
-          <StudyRecruitCard isMini isScraped />
-          <StudyRecruitCard isMini isScraped />
-          <StudyRecruitCard isMini isScraped />
-        </CardList>
-        <Button varient="ghost" addStyle="w-full h-[50px] rounded-[5px] border-gray-400 text-gray-800 mt-6">
-          스터디 전체보기
-        </Button>
-      </section>
+      {relatedStudyList.length !== 0 && (
+        <section className="mb-[50px]" id="related_study">
+          <Title addStyle="mb-5">
+            이 강의를 수강하는 스터디 <span className="text-main-500 ">{relatedStudyList.length}개</span>
+          </Title>
+          <CardList>
+            {relatedStudyList.slice(0, 4).map((study) => (
+              <StudyRecruitCard key={study._id} isMini isScraped />
+            ))}
+          </CardList>
+          <Button varient="ghost" addStyle="w-full h-[50px] rounded-[5px] border-gray-400 text-gray-800 mt-6">
+            스터디 전체보기
+          </Button>
+        </section>
+      )}
     </>
   );
 }

--- a/src/lib/database/action/lecture.ts
+++ b/src/lib/database/action/lecture.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { Lecture, LectureBookmark } from "@/schema/lectureSchema";
+import { TLectureDetailData } from "@/types/api/lecture";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
@@ -21,10 +22,11 @@ export const getLectureListAction = async () => {
   }
 };
 
-export const getLectureAction = async (id: string) => {
+export const getLectureAction = async (id: string): Promise<TLectureDetailData> => {
   try {
-    const lecture = await Lecture.findById(id);
-    return lecture;
+    const response = await fetch(`${process.env.LOCAL_URL}/api/lecture/${id}`);
+    const data = await response.json();
+    return data;
   } catch (error: any) {
     console.error("Error fetching lecture:", error.message);
     throw error;

--- a/src/schema/lectureSchema.ts
+++ b/src/schema/lectureSchema.ts
@@ -18,7 +18,6 @@ const lectureSchema = new mongoose.Schema({
   instructor: { type: String, required: true },
   level: { type: String, required: true },
   tag: [String],
-  lectureStudyList: [], // 강의에 해당하는 스터디 리스트 추가해야됨
   review: [lectureReviewSchema],
   createdAt: { type: Date, default: Date.now },
 });

--- a/src/schema/studySchema.ts
+++ b/src/schema/studySchema.ts
@@ -5,6 +5,7 @@ const studySchema = new mongoose.Schema(
     category: {
       type: String,
       enum: ["DESIGN", "DEVELOP", "BUSINESS", "MARKETING", "ECONOMY", "LANGUAGE", "LICENSE", "SELF-DEVELOPMENT"],
+      required: true,
     },
     ownerId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
     lectureId: { type: mongoose.Schema.Types.ObjectId, ref: "Lecture", required: true },
@@ -21,7 +22,6 @@ const studySchema = new mongoose.Schema(
      */
     imageUrl: {
       type: String,
-      required: true,
     },
     description: {
       type: String,

--- a/src/types/api/lecture.ts
+++ b/src/types/api/lecture.ts
@@ -1,0 +1,30 @@
+import { TStudyDetailInfoData } from "./study";
+
+export type TLectureInfoData = {
+  _id: string;
+  online: boolean;
+  category: string;
+  platform: string;
+  rating: number;
+  link: string;
+  title: string;
+  instructor: string;
+  level: string;
+  tag: string[];
+  lectureStudyList?: any[]; //제거 예정
+  review: {
+    reviewerId: string;
+    reviewer: string;
+    rating: number;
+    comment: string;
+    created_at: string;
+    _id: string;
+  }[];
+};
+
+export type TRelatedStudy = TStudyDetailInfoData;
+
+export type TLectureDetailData = {
+  lecture: TLectureInfoData;
+  relatedStudyList: TRelatedStudy[];
+};

--- a/src/types/api/study.ts
+++ b/src/types/api/study.ts
@@ -1,0 +1,35 @@
+export type TCategory =
+  | "DESIGN"
+  | "DEVELOP"
+  | "BUSINESS"
+  | "MARKETING"
+  | "ECONOMY"
+  | "LANGUAGE"
+  | "LICENSE"
+  | "SELF-DEVELOPMENT";
+
+export type TStudyDetailInfoData = {
+  _id: string;
+  ownerId: string;
+  category: TCategory;
+  lectureId: string;
+  title: string;
+  imageUrl: string;
+  description: string;
+  meeting: {
+    format: string;
+    platform: string;
+    schedule: {
+      day: string;
+      time: string;
+    };
+  };
+  startDate: string;
+  endDate: string;
+  moodKeywords: string[];
+  task: string[];
+  createdAt: string;
+  updateAt: string;
+  __v: number;
+  teamMemberId: string[];
+};


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 스크린샷

![image](이미지url)

## 구현 사항 설명
- 스터디 상세보기 api 리턴 값에 강의 정보 추가 
- 강의 상세보기 api 리턴 값에 관련 스터디 리스트 추가
- 스터디 모집완료 api
- 스터디 시작 api
- 스터디 완료 api

api 만 구현 완료 @@@@

- 강의 상세페이지 api 연결한거 일부 수정 했습니다 (관련 스터디 리스트 카드는 연결 해야함)



! 강의 상세페이지 헤더에 카테고리태그는 주민이랑 겹칠수도 있을거 같아서 일단 수정 안했어요~ 일단 렌더링 화면에는 빈칸으로 나올 것임!