### PR TITLE
Feat: 스터디 상세 페이지 api 연결

### DIFF
--- a/src/app/study/[id]/page.tsx
+++ b/src/app/study/[id]/page.tsx
@@ -2,13 +2,27 @@ import FixedBottomBar from "@/components/domains/detail/FixedBottomBar";
 import Header from "@/components/domains/detail/Header";
 import Contents from "@/components/domains/detail/study/Contents";
 
-export default function StudyDetail() {
+const getStudyInfo = async (id: string) => {
+  try {
+    const response = await fetch(`${process.env.LOCAL_URL}/api/study/${id}`);
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Error fetching study", error);
+    throw error;
+  }
+};
+
+export default async function StudyDetail({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const studyData = await getStudyInfo(id);
+
   return (
     <>
       <div className="flex-col inline-flex w-full h-dvh">
         <div className="flex-1 overflow-auto scrollbar-hide">
-          <Header page="study" />
-          <Contents />
+          <Header page="study" studyInfo={studyData.study} lectureInfo={studyData.lecture} />
+          <Contents study={studyData.study} lecture={studyData.lecture} memberList={studyData.teamMemberList} />
         </div>
         <FixedBottomBar page="study" />
       </div>

--- a/src/components/commons/card/LectureCard.tsx
+++ b/src/components/commons/card/LectureCard.tsx
@@ -4,13 +4,13 @@ import { TagMain } from "../tag/TagMain";
 import { TagLight } from "../tag/TagLight";
 import { TagRate } from "../tag/TagRate";
 import Link from "next/link";
-import { LectureData } from "@/app/lecture/[id]/page";
 import { CATEGORY } from "@/constant/category";
+import { TLectureInfoData } from "@/types/api/lecture";
 
 interface LectureCardProps {
   variant: "card" | "info";
   isScraped?: boolean;
-  lecture: LectureData;
+  lecture: TLectureInfoData;
 }
 
 export default function LectureCard({ isScraped, variant, lecture }: LectureCardProps) {

--- a/src/components/domains/detail/DetailInfo.tsx
+++ b/src/components/domains/detail/DetailInfo.tsx
@@ -3,11 +3,12 @@ import Image from "next/image";
 interface DetailInfoProps {
   icon: { src: string; alt: string };
   title: string;
-  content: string;
+  content?: string;
   isWhite?: boolean;
+  taskContent?: string[];
 }
 
-export default function DetailInfo({ icon, title, content, isWhite = false }: DetailInfoProps) {
+export default function DetailInfo({ icon, title, content, isWhite = false, taskContent }: DetailInfoProps) {
   return (
     <>
       <li
@@ -18,7 +19,7 @@ export default function DetailInfo({ icon, title, content, isWhite = false }: De
           <Image src={icon.src} alt={icon.alt} width={18} height={18} />
           <p>{title}</p>
         </div>
-        <p>{content}</p>
+        {taskContent ? taskContent.map((content, idx) => <p key={idx}>{content}</p>) : <p>{content}</p>}
       </li>
     </>
   );

--- a/src/components/domains/detail/FixedBottomBar.tsx
+++ b/src/components/domains/detail/FixedBottomBar.tsx
@@ -2,14 +2,14 @@ import UserActionButton from "@/components/domains/detail/UserActionButton";
 import ScrapButton from "@/components/commons/ScrapButton";
 interface FixedBottomBarProps {
   page: "lecture" | "study";
-  lectureId: string;
+  lectureId?: string;
 }
 
 export default function FixedBottomBar({ page, lectureId }: FixedBottomBarProps) {
   return (
     <>
       <footer className="sm:absolute fixed inset-x-0 bottom-0 flex items-center justify-between gap-1 h-[74px] bg-white px-4 py-3 drop-shadow-[0_35px_35px_rgba(0,0,0,0.25)]">
-        <ScrapButton variant="detail" lectureId={lectureId} />
+        <ScrapButton variant="detail" lectureId={lectureId || ""} />
         <UserActionButton page={page} />
       </footer>
     </>

--- a/src/components/domains/detail/Header.tsx
+++ b/src/components/domains/detail/Header.tsx
@@ -6,24 +6,50 @@ import { TagRate } from "@/components/commons/tag/TagRate";
 import { IMAGES_DEFAUlT } from "@/constant/images";
 import { CATEGORY } from "@/constant/category";
 import { TLectureInfoData } from "@/types/api/lecture";
+import { TStudyDetailInfoData } from "@/types/api/study";
 
 interface BannerProps {
   page: "study" | "lecture";
   lectureInfo: TLectureInfoData;
+  studyInfo?: TStudyDetailInfoData["study"];
 }
 
 const { study, lecture } = IMAGES_DEFAUlT;
 
-export default function Header({ page, lectureInfo }: BannerProps) {
-  const { online, platform, category, rating, title, link } = lectureInfo;
+export default function Header({ page, lectureInfo, studyInfo }: BannerProps) {
+  const { online: lectureOnline, platform, category: lectureCategory, rating, title: lectureTitle, link } = lectureInfo;
+  const studyOnline = studyInfo?.meeting?.format || "online";
+  const { category: studyCategory = "", title: studyTitle, startDate } = studyInfo || {};
   const studyImageUrl = ""; //임시
   const isStudy = page === "study";
   const defaultImageUrl = isStudy ? study.src : lecture.src;
   const imageUrl = isStudy ? studyImageUrl : "";
+  const studyStartDate = startDate
+    ? new Date(startDate).toLocaleDateString("ko-KR", {
+        month: "2-digit",
+        day: "2-digit",
+        weekday: "short",
+      })
+    : "";
   const style = {
     backgroundImage: `url(${imageUrl || defaultImageUrl})`,
   };
   const isLeader = true;
+
+  const getStatus = () => {
+    if (isStudy) {
+      switch (studyOnline) {
+        case "online":
+          return "온라인";
+        case "offline":
+          return "오프라인";
+        default:
+          return "온/오프라인";
+      }
+    } else {
+      return lectureOnline ? "온라인" : "오프라인";
+    }
+  };
 
   return (
     <>
@@ -34,8 +60,8 @@ export default function Header({ page, lectureInfo }: BannerProps) {
         style={style}>
         <TopBar variant="share" showMore={isStudy && isLeader} isWhite={isStudy} />
         <div className="flex items-center gap-1 mt-10 mb-4">
-          <TagMain>{online ? "온라인" : "오프라인"}</TagMain>
-          <TagLight>{CATEGORY(category)}</TagLight>
+          <TagMain>{getStatus()}</TagMain>
+          <TagLight>{CATEGORY(isStudy ? studyCategory : lectureCategory)}</TagLight>
           {!isStudy && (
             <>
               <TagLight>{platform}</TagLight>
@@ -46,18 +72,18 @@ export default function Header({ page, lectureInfo }: BannerProps) {
         <h1
           className="mx-11 text-center text-[18px] font-semibold leading-[150%] tracking-[0.6px] break-keep"
           style={{ color: isStudy ? "white" : "black" }}>
-          {title}
+          {isStudy ? studyTitle : lectureTitle}
         </h1>
         {isStudy && (
           <div className="mt-6 w-[149px] h-[18px] flex justify-start items-center gap-2.5 leading-[150%] tracking-[-0.36px] text-gray-400 text-[12px] font-medium text-nowrap ">
-            <p>4주 진행</p>
+            <p>몇주 진행</p>
             <div className="w-[1px] h-[12px] bg-gray-400" />
-            <p>06.21(일)부터 시작</p>
+            <p>{`${studyStartDate} 부터 시작`}</p>
           </div>
         )}
       </section>
       <section className="px-4 py-5">
-        <LectureLinkBanner href={link} title={title} />
+        <LectureLinkBanner href={link} title={lectureTitle} />
       </section>
     </>
   );

--- a/src/components/domains/detail/study/Contents.tsx
+++ b/src/components/domains/detail/study/Contents.tsx
@@ -2,8 +2,16 @@ import TabMenuLinkUnderlined from "@/components/commons/TabMenuLinkUnderlined";
 import RecruitInfo from "./RecruitInfo";
 import RecruitedMembersList from "./RecruitedMembersList";
 import RecruitComments from "./RecruitComments";
+import { TLectureInfoData } from "@/types/api/lecture";
+import { TStudyDetailInfoData } from "@/types/api/study";
 
-export default function Contents() {
+interface IContentsProps {
+  study: TStudyDetailInfoData["study"];
+  lecture: TLectureInfoData;
+  memberList: TStudyDetailInfoData["teamMemberList"];
+}
+
+export default function Contents({ study, lecture, memberList }: IContentsProps) {
   return (
     <>
       <div className="mb-[73px]">
@@ -13,8 +21,8 @@ export default function Contents() {
           <TabMenuLinkUnderlined title="댓글" isCurrent={false} href="#comments" />
         </nav>
         <div className="px-4 bg-gray-100 pb-12">
-          <RecruitInfo />
-          <RecruitedMembersList />
+          <RecruitInfo study={study} lecture={lecture} />
+          <RecruitedMembersList study={study} memberList={memberList} />
           <RecruitComments />
         </div>
       </div>

--- a/src/components/domains/detail/study/RecruitInfo.tsx
+++ b/src/components/domains/detail/study/RecruitInfo.tsx
@@ -7,57 +7,59 @@ import { MoodMiniTag } from "@/components/commons/tag/MoodMiniTag";
 import TagsLayout from "./elements/layouts/TagsLayout";
 import WantTeamTag from "./elements/WantTeamTag";
 import Title from "../Title";
+import { TLectureInfoData } from "@/types/api/lecture";
+import { TStudyDetailInfoData } from "@/types/api/study";
+
+interface IRecruitInfoProps {
+  study: TStudyDetailInfoData["study"];
+  lecture: TLectureInfoData;
+}
 
 const { teamMember, meeting, task, location } = STUDY_RECRUIT_INFO;
 
-export default function RecruitInfo() {
+export default function RecruitInfo({ study, lecture }: IRecruitInfoProps) {
   return (
     <>
       <article id="recruit_Info">
         <section className="flex flex-col gap-3 justify-start py-5">
-          <DetailInfo icon={teamMember.icon} title={teamMember.title} content="최대 4명" />
-          <DetailInfo icon={meeting.icon} title={meeting.title} content="매주 토요일 오후 8:00 진행" />
-          <DetailInfo icon={task.icon} title={task.title} content="스터디 게시판 사진 인증" />
-          <DetailInfo icon={location.icon} title={location.title} content="서울특별시 중구" />
+          <DetailInfo icon={teamMember.icon} title={teamMember.title} content={`최대 ${study.wantedMember.count}명`} />
+          <DetailInfo
+            icon={meeting.icon}
+            title={meeting.title}
+            content={`매주 ${study.meeting.schedule.day} ${study.meeting.schedule.time} 진행`}
+          />
+          <DetailInfo icon={task.icon} title={task.title} taskContent={study.task} />
+          <DetailInfo icon={location.icon} title={location.title} content={study.meeting.platform} />
         </section>
         <HorizontalDivider />
         <StudyDetailCardLayout addStyle="mt-5">
           <Title href="-">진행 강의 정보</Title>
           <HorizontalDivider addStyle="my-4" />
-          <LectureCard variant="info" />
+          <LectureCard variant="info" lecture={lecture} />
         </StudyDetailCardLayout>
         <StudyDetailCardLayout addStyle="mt-4">
           <Title>해당 스터디의 분위기</Title>
           <HorizontalDivider addStyle="my-4" />
           <TagsLayout>
-            <MoodMiniTag
-              src={USER_FAVORITE_FIELD_TYPE.friendly.src}
-              alt={`${USER_FAVORITE_FIELD_TYPE.friendly.alt} 아이콘`}>
-              {USER_FAVORITE_FIELD_TYPE.friendly.alt}
-            </MoodMiniTag>
-            <MoodMiniTag
-              src={USER_FAVORITE_FIELD_TYPE.friendly.src}
-              alt={`${USER_FAVORITE_FIELD_TYPE.friendly.alt} 아이콘`}>
-              {USER_FAVORITE_FIELD_TYPE.friendly.alt}
-            </MoodMiniTag>
-            <MoodMiniTag
-              src={USER_FAVORITE_FIELD_TYPE.friendly.src}
-              alt={`${USER_FAVORITE_FIELD_TYPE.friendly.alt} 아이콘`}>
-              {USER_FAVORITE_FIELD_TYPE.friendly.alt}
-            </MoodMiniTag>
+            {study.moodKeywords.map((mood: string, idx) => {
+              const moodData = USER_FAVORITE_FIELD_TYPE[mood as keyof typeof USER_FAVORITE_FIELD_TYPE];
+              return (
+                <MoodMiniTag key={idx} src={moodData?.src} alt={`${moodData?.alt} 아이콘`}>
+                  {moodData?.alt}
+                </MoodMiniTag>
+              );
+            })}
           </TagsLayout>
         </StudyDetailCardLayout>
         <StudyDetailCardLayout addStyle="mt-4">
           <Title>해당 스터디에서 원하는 팀원</Title>
           <HorizontalDivider addStyle="my-4" />
           <TagsLayout>
-            <WantTeamTag text="20대" />
-            <WantTeamTag text="비기너" />
+            <WantTeamTag text={study.wantedMember.age} />
+            <WantTeamTag text={study.wantedMember.career} />
           </TagsLayout>
           <TagsLayout addStyle="mt-3">
-            <WantTeamTag text="과제팀장" />
-            <WantTeamTag text="알림팀장" />
-            <WantTeamTag text="환경팀장" />
+            <WantTeamTag text={study.wantedMember.role} />
           </TagsLayout>
         </StudyDetailCardLayout>
       </article>

--- a/src/components/domains/detail/study/RecruitedMembersList.tsx
+++ b/src/components/domains/detail/study/RecruitedMembersList.tsx
@@ -3,52 +3,34 @@ import StudyDetailCardLayout from "./elements/layouts/StudyDetailCardLayout";
 
 import Title from "../Title";
 import MemberProfile from "./elements/MemberProfile";
-import { IMAGES_DEFAUlT } from "@/constant/images";
+import { TStudyDetailInfoData } from "@/types/api/study";
 
-type TMember = {
-  id: string;
-  nickname: string;
-  profileImageUrl: string;
-  isLeader: boolean;
-  role: string;
-};
+interface IRecruitedMembersListProps {
+  study: TStudyDetailInfoData["study"];
+  memberList: TStudyDetailInfoData["teamMemberList"];
+}
 
-const memberList: TMember[] = [
-  {
-    id: "1",
-    nickname: "웅진",
-    profileImageUrl: "",
-    isLeader: true,
-    role: "팀장",
-  },
-  {
-    id: "2",
-    nickname: "체리콜라",
-    profileImageUrl: "",
-    isLeader: false,
-    role: "기록팀장",
-  },
-  {
-    id: "3",
-    nickname: "취뽀고",
-    profileImageUrl: "",
-    isLeader: false,
-    role: "일정팀장",
-  },
-];
-
-export default function RecruitedMembersList() {
+export default function RecruitedMembersList({ study, memberList }: IRecruitedMembersListProps) {
   return (
     <>
       <article id="recruited_member">
         <StudyDetailCardLayout addStyle="mt-4">
           <Title>
-            팀원 프로필<span className="text-main-500 ml-2">3/4</span>
+            팀원 프로필
+            <span className="text-main-500 ml-2">
+              {memberList.length}/{study.wantedMember.count}
+            </span>
           </Title>
           <HorizontalDivider addStyle="my-4" />
           <div className="flex flex-col gap-1 justify-start">
-            {memberList.map((member) => (
-              <MemberProfile key={member.id} {...member} />
+            {memberList?.map((member) => (
+              <MemberProfile
+                key={member.memberId}
+                nickname={member.nickname}
+                profileImageUrl={member.profileImageUrl}
+                role={member.role}
+                isLeader={member.isOwner}
+              />
             ))}
           </div>
         </StudyDetailCardLayout>

--- a/src/components/domains/detail/study/elements/WantTeamTag.tsx
+++ b/src/components/domains/detail/study/elements/WantTeamTag.tsx
@@ -1,11 +1,15 @@
 //추후 태그 컴포넌트들 리팩토링시 제거
 
-export default function WantTeamTag({ text }: { text: string }) {
+export default function WantTeamTag({ text }: { text: string[] }) {
   return (
     <>
-      <span className="inline-flex items-center h-[33px] px-3 text-center border border-main-500 rounded-[3px] text-[14px] font-medium  text-main-500 tracking-[-0.42px]">
-        {text}
-      </span>
+      {text.map((text, idx) => (
+        <span
+          key={idx}
+          className="inline-flex items-center h-[33px] px-3 text-center border border-main-500 rounded-[3px] text-[14px] font-medium  text-main-500 tracking-[-0.42px]">
+          {text}
+        </span>
+      ))}
     </>
   );
 }

--- a/src/constant/category.ts
+++ b/src/constant/category.ts
@@ -1,13 +1,13 @@
 export const CATEGORY = (category: string): string | undefined => {
   const categoryList: Record<string, string> = {
-    design: "디자인",
-    develop: "개발 · 테크",
-    marketing: "마케팅",
-    business: "비즈니스",
-    economic: "경제",
-    language: "외국어",
-    certificate: "자격증",
-    selfDevelop: "자기 계발",
+    DESIGN: "디자인",
+    DEVELOP: "개발 · 테크",
+    MARKETING: "마케팅",
+    BUSINESS: "비즈니스",
+    ECONOMY: "경제",
+    LANGUAGE: "외국어",
+    LICENSE: "자격증",
+    "SELF-DEVELOPMENT": "자기 계발",
   };
 
   return categoryList[category];

--- a/src/types/api/study.ts
+++ b/src/types/api/study.ts
@@ -1,3 +1,5 @@
+import { TLectureInfoData } from "./lecture";
+
 export type TCategory =
   | "DESIGN"
   | "DEVELOP"
@@ -43,8 +45,8 @@ type TStudyDetail = {
       time: string;
     };
   };
-  startDate: string;
-  endDate: string;
+  startDate: Date;
+  endDate: Date;
   moodKeywords: string[];
   task: string[];
   wantedMember: {
@@ -62,6 +64,6 @@ type TStudyDetail = {
 
 export type TStudyDetailInfoData = {
   study: TStudyDetail;
-  lecture: TRelatedLecture;
+  lecture: TLectureInfoData;
   teamMemberList: TTeamMember[];
 };


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 스크린샷
<img width="638" alt="스크린샷 2024-07-15 02 17 44" src="https://github.com/user-attachments/assets/351031d6-47c4-41f3-b621-a373aa2a2f17">
<img width="705" alt="스크린샷 2024-07-15 02 17 59" src="https://github.com/user-attachments/assets/e441e131-ebe2-4f26-96e5-d24a8e975963">


## 구현 사항 설명
api 연결 완료했습니다.
연결하면서 필요한 프롭이나, 수정된 타입 제목들이 적용되지 않은 것들이 많아서 최대한 통일시키면서 작업했습니다.
진행기간 같은 경우에는 주민님이 유틸에 올려주신다고 해서 유틸에 추가되면 적용하겠습니다.

정보, 팀원, 댓글 탭 관련해서 스크롤 위치에 따른 활성 상태 적용해야 할 것 같습니다.