### PR TITLE
Fix: 강의, 스터디 상세페이지 tabMenu 수정

### DIFF
--- a/src/components/commons/DetailTabMenu.tsx
+++ b/src/components/commons/DetailTabMenu.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import TabMenuLinkUnderlined from "./TabMenuLinkUnderlined";
+
+interface TabInfo {
+  title: string;
+  href: string;
+}
+
+interface IDetailTabMenuLinkUnderlinedProps {
+  type: "lecture" | "study";
+}
+
+export default function DetailTabMenu({ type }: IDetailTabMenuLinkUnderlinedProps) {
+  const lectureTabs: TabInfo[] = [
+    { title: "강의소개", href: "#lectureInfo" },
+    { title: "스터디", href: "#related_study" },
+    { title: "평점", href: "#rating" },
+  ];
+
+  const studyTabs: TabInfo[] = [
+    { title: "정보", href: "#recruit_Info" },
+    { title: "팀원", href: "#recruited_member" },
+    { title: "댓글", href: "#comments" },
+  ];
+
+  const tabs = type === "lecture" ? lectureTabs : studyTabs;
+  const [currentTab, setCurrentTab] = useState<string>(tabs[0].href);
+
+  const handleClick = (tabId: string) => {
+    setCurrentTab(tabId);
+  };
+
+  return (
+    <nav className="flex justify-between items-center gap-3 bg-white sticky top-0 left-0 z-sticky">
+      {tabs.map((tab) => (
+        <TabMenuLinkUnderlined
+          key={tab.href}
+          title={tab.title}
+          isCurrent={currentTab === tab.href}
+          href={tab.href}
+          onClick={() => handleClick(tab.href)}
+        />
+      ))}
+    </nav>
+  );
+}

--- a/src/components/commons/TabMenuLinkUnderlined.tsx
+++ b/src/components/commons/TabMenuLinkUnderlined.tsx
@@ -5,16 +5,18 @@ interface ITabMenuLinkUnderlinedProps {
   isCurrent: boolean;
   title: string;
   count?: number;
+  onClick?: () => void;
 }
 
 export default function TabMenuLinkUnderlined(props: ITabMenuLinkUnderlinedProps) {
-  const { href, title, isCurrent } = props;
+  const { href, title, isCurrent, onClick } = props;
   return (
     <Link
       className={`w-full flex justify-center items-center gap-1 py-3 border-b-2 text-sm font-medium leading-snug tracking-[-0.42px] ${
         isCurrent ? "border-b-3 text-main-500 border-main-500" : "border-gray-300"
       }`}
-      href={href}>
+      href={href}
+      onClick={onClick}>
       <span>{title}</span>
       {props?.count && <span>{props.count}</span>}
     </Link>

--- a/src/components/domains/detail/lecture/Contents.tsx
+++ b/src/components/domains/detail/lecture/Contents.tsx
@@ -1,8 +1,8 @@
-import TabMenuLinkUnderlined from "@/components/commons/TabMenuLinkUnderlined";
 import LectureInfo from "./LectureInfo";
 import LectureRatings from "./LectureRatings";
 import LectureRelatedStudies from "./LectureRelatedStudies";
 import { TLectureDetailData } from "@/types/api/lecture";
+import DetailTabMenu from "@/components/commons/DetailTabMenu";
 
 interface ContentsProps {
   lectureData: TLectureDetailData;
@@ -12,16 +12,12 @@ export default function Contents({ lectureData }: ContentsProps) {
   const { lecture, relatedStudyList } = lectureData;
 
   return (
-    <div className="mb-[73px]">
-      <nav className="flex justify-between items-center gap-3 bg-white sticky top-0 left-0 z-sticky">
-        <TabMenuLinkUnderlined title="강의소개" isCurrent={true} href="#lectureInfo" />
-        <TabMenuLinkUnderlined title="스터디" isCurrent={false} href="#related_study" />
-        <TabMenuLinkUnderlined title="평점" isCurrent={false} href="#rating" />
-      </nav>
+    <div className="mb-[73px]" id="lectureInfo">
+      <DetailTabMenu type="lecture" />
       <div className="px-4 sm:overflow-y-auto">
         <LectureInfo lectureInfo={lecture} />
-        <LectureRelatedStudies relatedStudyList={relatedStudyList} />
-        <LectureRatings lectureInfo={lecture} />
+        <LectureRelatedStudies key="related_studies" relatedStudyList={relatedStudyList} />
+        <LectureRatings key="ratings" lectureInfo={lecture} />
       </div>
     </div>
   );

--- a/src/components/domains/detail/lecture/LectureInfo.tsx
+++ b/src/components/domains/detail/lecture/LectureInfo.tsx
@@ -12,12 +12,12 @@ const { instructor, level } = LECTURE_INFO;
 export default function LectureInfo({ lectureInfo }: LectureInfoProps) {
   return (
     <>
-      <section className="pt-7 pb-10" id="lectureInfo">
+      <section className="pt-7 pb-10">
         <div className="flex flex-col gap-3 justify-start">
           <DetailInfo icon={instructor.icon} title={instructor.title} content={lectureInfo?.instructor} />
           <DetailInfo icon={level.icon} title={level.title} content={lectureInfo?.level} />
         </div>
-        <div className="flex items-center gap-[14px] mt-5">
+        <div className="flex items-center gap-[14px] mt-5" id="related_study">
           {lectureInfo?.tag.map((tag: string, index: number) => (
             <HashTag key={index} tag={tag} />
           ))}

--- a/src/components/domains/detail/lecture/LectureRelatedStudies.tsx
+++ b/src/components/domains/detail/lecture/LectureRelatedStudies.tsx
@@ -12,7 +12,7 @@ export default function LectureRelatedStudies({ relatedStudyList }: LectureRelat
   return (
     <>
       {relatedStudyList.length !== 0 && (
-        <section className="mb-[50px]" id="related_study">
+        <section className="mb-[50px]">
           <Title addStyle="mb-5">
             이 강의를 수강하는 스터디 <span className="text-main-500 ">{relatedStudyList.length}개</span>
           </Title>

--- a/src/components/domains/detail/study/Contents.tsx
+++ b/src/components/domains/detail/study/Contents.tsx
@@ -1,9 +1,9 @@
-import TabMenuLinkUnderlined from "@/components/commons/TabMenuLinkUnderlined";
 import RecruitInfo from "./RecruitInfo";
 import RecruitedMembersList from "./RecruitedMembersList";
 import RecruitComments from "./RecruitComments";
 import { TLectureInfoData } from "@/types/api/lecture";
 import { TStudyDetailInfoData } from "@/types/api/study";
+import DetailTabMenu from "@/components/commons/DetailTabMenu";
 
 interface IContentsProps {
   study: TStudyDetailInfoData["study"];
@@ -14,12 +14,8 @@ interface IContentsProps {
 export default function Contents({ study, lecture, memberList }: IContentsProps) {
   return (
     <>
-      <div className="mb-[73px]">
-        <nav className="flex justify-between items-center gap-3 bg-gray-100 sticky top-0 left-0 z-sticky">
-          <TabMenuLinkUnderlined title="정보" isCurrent={true} href="#recruit_Info" />
-          <TabMenuLinkUnderlined title="팀원" isCurrent={false} href="#recruited_member" />
-          <TabMenuLinkUnderlined title="댓글" isCurrent={false} href="#comments" />
-        </nav>
+      <div className="mb-[73px]" id="recruit_Info">
+        <DetailTabMenu type="study" />
         <div className="px-4 bg-gray-100 pb-12">
           <RecruitInfo study={study} lecture={lecture} />
           <RecruitedMembersList study={study} memberList={memberList} />

--- a/src/components/domains/detail/study/RecruitInfo.tsx
+++ b/src/components/domains/detail/study/RecruitInfo.tsx
@@ -20,7 +20,7 @@ const { teamMember, meeting, task, location } = STUDY_RECRUIT_INFO;
 export default function RecruitInfo({ study, lecture }: IRecruitInfoProps) {
   return (
     <>
-      <article id="recruit_Info">
+      <article>
         <section className="flex flex-col gap-3 justify-start py-5">
           <DetailInfo icon={teamMember.icon} title={teamMember.title} content={`최대 ${study.wantedMember.count}명`} />
           <DetailInfo


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정

## 스크린샷

https://github.com/user-attachments/assets/c7940e0b-6705-4cbd-b72e-f912204d1793

https://github.com/user-attachments/assets/ce1db8d1-7a78-4ef6-b285-55662f82f909

## 구현 사항 설명
- 강의, 스터디 상세페이지 tabMenu 위치 수정 및 해당 탭 클릭 시 포인트 색 변환 기능 수정했습니다
- 스터디 상세페이지에 데이터가 그대로 들어가는 부분은 오늘 중으로 수정해서 pr 올리겠습니다