### PR TITLE
Feat: 스터디 상세 페이지 유저 관계 api 연결 및 스터디, 강의 북마크 구현

### DIFF
--- a/src/app/api/study/[id]/bookmark/route.ts
+++ b/src/app/api/study/[id]/bookmark/route.ts
@@ -80,10 +80,10 @@ export async function DELETE(req: Request): Promise<NextResponse> {
 
     const response = await StudyBookmark.findByIdAndDelete(_id);
     if (!response) {
-      return NextResponse.json({ message: "댓글을 찾을 수 없습니다." }, { status: 404 });
+      return NextResponse.json({ message: "사용자를 찾을 수 없습니다." }, { status: 404 });
     }
 
-    return NextResponse.json("강의 찜 삭제 성공!");
+    return NextResponse.json("스터디 찜 삭제 성공!");
   } catch (error: any) {
     throw new Error(error);
   }

--- a/src/app/api/study/[id]/route.ts
+++ b/src/app/api/study/[id]/route.ts
@@ -38,15 +38,17 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
         teamMembers.members.map(async (member: any) => {
           const user = await User.findById(member.userId);
           return {
-            memberId: member.id,
+            memberId: member.userId,
             nickname: user.nickname,
             profileImageUrl: user.profileImageUrl,
             role: member.role,
             isOwner: member.isOwner,
+            status: member.status,
           };
         }),
       );
     }
+
     return Response.json({ study, lecture: lectureResult, teamMemberList: acceptedTeamMembers }, { status: 200 });
   } catch (error: any) {
     if (error.name === "CastError") {

--- a/src/app/study/[id]/layout.tsx
+++ b/src/app/study/[id]/layout.tsx
@@ -2,8 +2,8 @@ import Button from "@/components/commons/Button";
 import { ReactNode } from "react";
 
 export default function layout({ children }: { children: ReactNode }) {
-  const isLeader = true;
-  const isDone = true;
+  const isLeader = false;
+  const isDone = false;
   return (
     <>
       {children}

--- a/src/app/study/[id]/page.tsx
+++ b/src/app/study/[id]/page.tsx
@@ -41,7 +41,7 @@ export default async function StudyDetail({ params }: { params: { id: string } }
             commentList={commentData}
           />
         </div>
-        <FixedBottomBar page="study" id={id} />
+        <FixedBottomBar page="study" id={id} study={studyData} />
       </div>
     </>
   );

--- a/src/components/domains/detail/FixedBottomBar.tsx
+++ b/src/components/domains/detail/FixedBottomBar.tsx
@@ -1,12 +1,14 @@
 import UserActionButton from "@/components/domains/detail/UserActionButton";
 import ScrapButton from "@/components/commons/ScrapButton";
 import { getSession } from "@/lib/database/getSession";
+import { TStudyDetailInfoData } from "@/types/api/study";
 interface FixedBottomBarProps {
   page: "lecture" | "study";
   id: string;
+  study: TStudyDetailInfoData;
 }
 
-export default async function FixedBottomBar({ page, id }: FixedBottomBarProps) {
+export default async function FixedBottomBar({ page, id, study }: FixedBottomBarProps) {
   const session = await getSession();
   const userId = session?.user?.id || "";
 
@@ -14,7 +16,7 @@ export default async function FixedBottomBar({ page, id }: FixedBottomBarProps) 
     <>
       <footer className="sm:absolute fixed inset-x-0 bottom-0 flex items-center justify-between gap-1 h-[74px] bg-white px-4 py-3 drop-shadow-[0_35px_35px_rgba(0,0,0,0.25)]">
         <ScrapButton variant="detail" page={page} id={id || ""} userId={userId} />
-        <UserActionButton page={page} />
+        <UserActionButton page={page} userId={userId} study={study} />
       </footer>
     </>
   );

--- a/src/components/domains/detail/FixedBottomBar.tsx
+++ b/src/components/domains/detail/FixedBottomBar.tsx
@@ -1,15 +1,19 @@
 import UserActionButton from "@/components/domains/detail/UserActionButton";
 import ScrapButton from "@/components/commons/ScrapButton";
+import { getSession } from "@/lib/database/getSession";
 interface FixedBottomBarProps {
   page: "lecture" | "study";
   id: string;
 }
 
-export default function FixedBottomBar({ page, id }: FixedBottomBarProps) {
+export default async function FixedBottomBar({ page, id }: FixedBottomBarProps) {
+  const session = await getSession();
+  const userId = session?.user?.id || "";
+
   return (
     <>
       <footer className="sm:absolute fixed inset-x-0 bottom-0 flex items-center justify-between gap-1 h-[74px] bg-white px-4 py-3 drop-shadow-[0_35px_35px_rgba(0,0,0,0.25)]">
-        <ScrapButton variant="detail" page={page} id={id || ""} />
+        <ScrapButton variant="detail" page={page} id={id || ""} userId={userId} />
         <UserActionButton page={page} />
       </footer>
     </>

--- a/src/components/domains/detail/UserActionButton.tsx
+++ b/src/components/domains/detail/UserActionButton.tsx
@@ -1,12 +1,31 @@
 import Button from "@/components/commons/Button";
 import userActionButtonConfig from "@/constant/userActionButtonConfig";
+import { TStudyDetailInfoData } from "@/types/api/study";
 
 interface UserActionButtonProps {
   page: "lecture" | "study";
+  userId: string;
+  study: TStudyDetailInfoData;
 }
 
-export default function UserActionButton({ page }: UserActionButtonProps) {
-  const userStatus = "NOT_APPLIED"; //임시
+export default function UserActionButton({ page, userId, study }: UserActionButtonProps) {
+  let userStatus: keyof typeof userActionButtonConfig.study;
+  const teamMemberInfo = study?.teamMemberList?.find((member) => member.memberId === userId);
+
+  switch (true) {
+    case userId === study?.study.ownerId:
+      userStatus = "OWNER";
+      break;
+    case teamMemberInfo?.status === "ACCEPTED":
+      userStatus = "ACCEPTED";
+      break;
+    case teamMemberInfo?.status === "APPLIED" || teamMemberInfo?.status === "APPLIED_VIEW":
+      userStatus = "APPLIED";
+      break;
+    default:
+      userStatus = "NOT_APPLIED";
+  }
+
   const buttonConfig = page === "lecture" ? userActionButtonConfig.lecture : userActionButtonConfig.study[userStatus];
 
   return (

--- a/src/components/domains/detail/study/Contents.tsx
+++ b/src/components/domains/detail/study/Contents.tsx
@@ -8,7 +8,7 @@ import DetailTabMenu from "@/components/commons/DetailTabMenu";
 
 interface IContentsProps {
   study: TStudyDetailInfoData["study"];
-  lecture: TLectureInfoData;
+  lecture: TStudyDetailInfoData["lecture"];
   memberList: TStudyDetailInfoData["teamMemberList"];
   commentList: TComment[];
 }

--- a/src/components/domains/detail/study/RecruitInfo.tsx
+++ b/src/components/domains/detail/study/RecruitInfo.tsx
@@ -19,15 +19,17 @@ const { teamMember, meeting, task, location } = STUDY_RECRUIT_INFO;
 
 export default function RecruitInfo({ study, lecture }: IRecruitInfoProps) {
   const renderTags = (items: string[], list: { [key: string]: string | { name: string } }) => {
-    return items.map((item) => (
-      <span
-        key={item}
-        className="inline-flex items-center h-[33px] px-3 text-center border border-main-500 rounded-[3px] text-[14px] font-medium text-main-500 tracking-[-0.42px]">
-        {typeof list[item] === "string" ? list[item] : list[item].name}
-      </span>
-    ));
+    return items.map((item) => {
+      const listItem = list[item];
+      return (
+        <span
+          key={item}
+          className="inline-flex items-center h-[33px] px-3 text-center border border-main-500 rounded-[3px] text-[14px] font-medium text-main-500 tracking-[-0.42px]">
+          {typeof listItem === "string" ? listItem : listItem.name}
+        </span>
+      );
+    });
   };
-
   return (
     <article id="recruit_Info">
       <section className="flex flex-col gap-3 justify-start py-5">

--- a/src/components/domains/detail/study/RecruitedMembersList.tsx
+++ b/src/components/domains/detail/study/RecruitedMembersList.tsx
@@ -12,30 +12,28 @@ interface IRecruitedMembersListProps {
 
 export default function RecruitedMembersList({ study, memberList }: IRecruitedMembersListProps) {
   return (
-    <>
-      <article id="recruited_member">
-        <StudyDetailCardLayout addStyle="mt-4">
-          <Title>
-            팀원 프로필
-            <span className="text-main-500 ml-2">
-              {memberList.filter((member) => member.status === "ACCEPTED").length}/{study.wantedMember.count}
-            </span>
-          </Title>
-          <HorizontalDivider addStyle="my-4" />
-          <div className="flex flex-col gap-1 justify-start">
-            {memberList?.map((member) => (
-              <MemberProfile
-                key={member.memberId}
-                nickname={member.nickname}
-                profileImageUrl={member.profileImageUrl}
-                role={member.role}
-                isLeader={member.isOwner}
-                status={member.status}
-              />
-            ))}
-          </div>
-        </StudyDetailCardLayout>
-      </article>
-    </>
+    <article id="recruited_member">
+      <StudyDetailCardLayout addStyle="mt-4">
+        <Title>
+          팀원 프로필
+          <span className="text-main-500 ml-2">
+            {memberList.filter((member) => member.status === "ACCEPTED").length}/{study.wantedMember.count}
+          </span>
+        </Title>
+        <HorizontalDivider addStyle="my-4" />
+        <div className="flex flex-col gap-1 justify-start">
+          {memberList?.map((member) => (
+            <MemberProfile
+              key={member.memberId}
+              nickname={member.nickname}
+              profileImageUrl={member.profileImageUrl}
+              role={member.role}
+              isLeader={member.isOwner}
+              status={member.status}
+            />
+          ))}
+        </div>
+      </StudyDetailCardLayout>
+    </article>
   );
 }

--- a/src/components/domains/detail/study/RecruitedMembersList.tsx
+++ b/src/components/domains/detail/study/RecruitedMembersList.tsx
@@ -18,7 +18,7 @@ export default function RecruitedMembersList({ study, memberList }: IRecruitedMe
           <Title>
             팀원 프로필
             <span className="text-main-500 ml-2">
-              {memberList.length}/{study.wantedMember.count}
+              {memberList.filter((member) => member.status === "ACCEPTED").length}/{study.wantedMember.count}
             </span>
           </Title>
           <HorizontalDivider addStyle="my-4" />
@@ -30,6 +30,7 @@ export default function RecruitedMembersList({ study, memberList }: IRecruitedMe
                 profileImageUrl={member.profileImageUrl}
                 role={member.role}
                 isLeader={member.isOwner}
+                status={member.status}
               />
             ))}
           </div>

--- a/src/components/domains/detail/study/elements/MemberProfile.tsx
+++ b/src/components/domains/detail/study/elements/MemberProfile.tsx
@@ -1,17 +1,17 @@
 import Avatar from "@/components/commons/Avatar";
-import Button from "@/components/commons/Button";
 
 interface MemberProfileProps {
   nickname: string;
   role: string;
   isLeader: boolean;
   profileImageUrl: string;
+  status: string;
 }
 
-export default function MemberProfile({ nickname, role, profileImageUrl, isLeader }: MemberProfileProps) {
+export default function MemberProfile({ nickname, role, profileImageUrl, isLeader, status }: MemberProfileProps) {
   return (
-    <>
-      <div className="flex items-center justify-between py-2">
+    <div className="flex items-center justify-between py-2">
+      {status === "ACCEPTED" && (
         <div className="flex items-center gap-2">
           <Avatar profileImageUrl={profileImageUrl} width={38} height={38} />
           <div className="flex flex-col">
@@ -27,12 +27,7 @@ export default function MemberProfile({ nickname, role, profileImageUrl, isLeade
             <p className="text-[12px] text-gray-700">{role}</p>
           </div>
         </div>
-        {isLeader && (
-          <Button varient="filled" className="text-xs bg-main-500 px-2 py-1 rounded-[5px] text-white leading-[150%]">
-            1:1 채팅
-          </Button>
-        )}
-      </div>
-    </>
+      )}
+    </div>
   );
 }

--- a/src/lib/database/action/bookmark.ts
+++ b/src/lib/database/action/bookmark.ts
@@ -39,7 +39,7 @@ export const deleteBookmarkAction = async (type: string, typeId: string, _id: st
     });
 
     if (!response.ok) {
-      throw new Error("강의 북마크 삭제 실패");
+      throw new Error(`${type === "study" ? "스터디" : "강의"} 북마크 삭제 실패`);
     }
 
     revalidatePath("/lecture", "layout");

--- a/src/types/api/study.ts
+++ b/src/types/api/study.ts
@@ -1,6 +1,5 @@
 import { TRole } from "@/constant/teamMemberInfo";
 import { TLectureInfoData } from "./lecture";
-import mongoose from "mongoose";
 
 export type TCategory =
   | "DESIGN"
@@ -18,6 +17,7 @@ type TTeamMember = {
   profileImageUrl: string;
   role: TRole;
   isOwner: boolean;
+  status: string;
 };
 
 type TStudyDetail = {


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정

## 스크린샷
- 유저 상태가 "ACCEPTED" 일 경우
<img width="632" alt="스크린샷 2024-07-18 00 02 32" src="https://github.com/user-attachments/assets/3e020c82-cd7d-428f-821d-ed42606ab731">

*****
- 유저 상태가 "APPLIED" or "APPLIED_VIEW" 일 경우
<img width="626" alt="스크린샷 2024-07-18 00 05 42" src="https://github.com/user-attachments/assets/00fa65c6-146f-4d3a-8a0b-4e1a03870c62">

*****
- 북마크 기능 구현

https://github.com/user-attachments/assets/51c560b9-d6a6-4ae1-ad57-15c0c8d6e8e5





## 구현 사항 설명

- 스터디 북마크 구현했습니다.
  - 해당 스터디에 관한 것만 내려와야하는데, 모든 북마크 카운트를 가지고 오는 코드로 작성되어 있어서 수정했습니다.
  - 강의 북마크도 적용해놨습니다.
- 각 유저의 상태에 따른 버튼 구현했습니다.
  1. 유저id === 개설자id 일 경우 => "OWNER"
  2. 팀 멤버 내, 유저 상태가 "APPLIED" or "APPLIED_VIEW" 일 경우 => "APPLIED"
  3. 팀 멤버 내, 유저 상태가 "ACCEPTED" 일 경우 => "ACCEPTED"
  4. 나머지는 => "NOT_APPLIED"
- 팀원 프로필에 승인되지 않은 멤버들도 표기가 되는 상황으로 구현되어 있어서 승인된 팀원만 보여지도록 수정하였습니다.


질문) 몽고디비에 applications 라는 폴더가 있던데, 그건 무슨 용도인지 알 수 있을가욥 유저 대표 지원서인가????