### PR TITLE
Feat: 강의 상세페이지 등  모집카드들 api 연결 (마이페이지 북마크된 스터디목록 제외), 강의상세페이지, 스터디상세페이지 지원하기 모집하기 버튼 연결 

### DIFF
--- a/src/app/(matching)/matching/success/page.tsx
+++ b/src/app/(matching)/matching/success/page.tsx
@@ -1,20 +1,40 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import AlertMessage from "@/components/commons/AlertMessage";
 import CardList from "@/components/commons/CardList";
 import { StudyRecruitCard } from "@/components/commons/card/StudyRecruitCard";
 import Button from "@/components/commons/Button";
 import Link from "next/link";
 import { useUserStore } from "@/store/userStore";
+import { useMatchingStore } from "@/store/matchingStore";
+import { TCategory, TStudyRecruitCardData } from "@/types/api/study";
+import NoResultText from "@/components/commons/NoResultText";
+import { CATEGORY_MAP_TO_KO } from "@/utils/categoryMap";
 
 export default function SuccessPage() {
   const { user, fetchUser } = useUserStore();
+  const { matching } = useMatchingStore();
+  const [studyList, setStudyList] = useState<TStudyRecruitCardData[]>();
+  const repLevel = JSON.parse(matching?.levels || "[]")[0];
+  const userInterestCategory = repLevel?.interest;
+
+  const fetchUserCategoryStudyList = async (category: TCategory) => {
+    try {
+      const res = await fetch(`/api/study/list?category=${category}&pageSize=6`);
+      const data = await res.json();
+      const { studyList } = data;
+      setStudyList(studyList);
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   useEffect(() => {
     if (!user) {
       fetchUser();
     }
+    fetchUserCategoryStudyList(userInterestCategory);
   }, [user]);
 
   return (
@@ -22,13 +42,15 @@ export default function SuccessPage() {
       <div className="flex flex-1 flex-col gap-[70px] w-full mt-[70px]">
         <AlertMessage varient="matching" />
         <div className="flex flex-col gap-5 w-full">
-          <h1 className="text-gray-900 text-[16px] font-[600] tracking-[-0.32px] leading-[24px]">{`${user?.nickname}님에게 딱 맞는 팀원 추천`}</h1>
+          <h1 className="text-gray-900 text-[16px] font-[600] tracking-[-0.32px] leading-[24px]">{`${user?.nickname}님에게 딱 맞는 스터디 추천`}</h1>
           <CardList isSingleLine>
-            {/* <StudyRecruitCard isMini={false} isScraped />
-            <StudyRecruitCard isMini={false} isScraped />
-            <StudyRecruitCard isMini={false} isScraped />
-            <StudyRecruitCard isMini={false} isScraped />
-            <StudyRecruitCard isMini={false} isScraped /> */}
+            {studyList?.length !== 0 ? (
+              studyList?.map((study) => <StudyRecruitCard isMini={false} isScraped={false} recruitCardData={study} />)
+            ) : (
+              <NoResultText>{`${
+                CATEGORY_MAP_TO_KO[userInterestCategory] || "관심"
+              }분야의 첫번째 스터디를 개설해 보세요!`}</NoResultText>
+            )}
           </CardList>
         </div>
       </div>

--- a/src/app/api/lecture/[id]/route.ts
+++ b/src/app/api/lecture/[id]/route.ts
@@ -1,6 +1,8 @@
 import connectDB from "@/lib/database/db";
 import { Lecture } from "@/schema/lectureSchema";
 import { Study } from "@/schema/studySchema";
+import { TeamMembers } from "@/schema/teamMemberSchema";
+import { TStudyListData } from "@/types/api/study";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const id = params.id;
@@ -12,7 +14,33 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
       return Response.json({ message: "해당 강의가 존재하지 않습니다." }, { status: 404 });
     }
 
-    const relatedStudyList = await Study.find({ lectureId: id, status: "RECRUIT_START" });
+    const relatedStudyListData = await Study.find({ lectureId: id, status: "RECRUIT_START" });
+
+    let relatedStudyList: TStudyListData = [];
+
+    //isBookmark 추가 예정.
+    if (relatedStudyListData) {
+      relatedStudyList = await Promise.all(
+        relatedStudyListData.map(async (study) => {
+          const { _id, ownerId, category, title, imageUrl, startDate, endDate, meeting, wantedMember } = study;
+          const acceptedTeamMembers = await TeamMembers.findOne({ studyId: _id, "members.status": "ACCEPTED" });
+          const acceptedCount = acceptedTeamMembers ? acceptedTeamMembers.members.length : 0;
+          const wantedMemberCount = wantedMember?.count || "제한없음";
+          return {
+            id: _id.toString(),
+            ownerId,
+            category,
+            title,
+            imageUrl,
+            startDate,
+            endDate,
+            meeting,
+            wantedMemberCount,
+            acceptedTeamMemberCount: acceptedCount,
+          };
+        }),
+      );
+    }
 
     return Response.json({ lecture, relatedStudyList });
   } catch (error: any) {

--- a/src/components/commons/card/StudyRecruitCard.tsx
+++ b/src/components/commons/card/StudyRecruitCard.tsx
@@ -13,11 +13,11 @@ import { CATEGORY_MAP_TO_KO } from "@/utils/categoryMap";
 interface IStudyRecruitCardProps {
   isMini?: boolean;
   isScraped?: boolean;
-  RecruitCardData: TStudyRecruitCardData;
+  recruitCardData: TStudyRecruitCardData;
   onClick?: () => void;
 }
 
-export function StudyRecruitCard({ isMini, isScraped, RecruitCardData, onClick }: IStudyRecruitCardProps) {
+export function StudyRecruitCard({ isMini, isScraped, recruitCardData, onClick }: IStudyRecruitCardProps) {
   const {
     category,
     title,
@@ -28,7 +28,7 @@ export function StudyRecruitCard({ isMini, isScraped, RecruitCardData, onClick }
     wantedMemberCount,
     acceptedTeamMemberCount,
     isBookmark,
-  } = RecruitCardData;
+  } = recruitCardData;
   const formattedStartDate = formatDate(startDate);
   const formattedEndDate = formatDate(endDate);
   const studySchedule =

--- a/src/components/domains/detail/UserActionButton.tsx
+++ b/src/components/domains/detail/UserActionButton.tsx
@@ -3,7 +3,7 @@ import Button from "@/components/commons/Button";
 import userActionButtonConfig from "@/constant/userActionButtonConfig";
 import { deleteMember, endRecurit } from "@/lib/database/action/teamMemberStatus";
 import { TStudyDetailInfoData } from "@/types/api/study";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 interface UserActionButtonProps {
   page: "lecture" | "study";
@@ -13,13 +13,15 @@ interface UserActionButtonProps {
 
 export default function UserActionButton({ page, userId, study }: UserActionButtonProps) {
   const router = useRouter();
+  const { id } = useParams();
+
   let userStatus: keyof typeof userActionButtonConfig.study;
   let userAction;
-  const teamMemberInfo = study?.teamMemberList?.find((member) => member.memberId === userId);
-  const studyData = study.study;
+  const teamMemberInfo = study?.teamMemberList?.find((member) => member?.memberId === userId);
+  const studyData = study?.study;
 
   switch (true) {
-    case userId === studyData.ownerId:
+    case userId === studyData?.ownerId:
       userStatus = "OWNER";
       userAction = endRecurit;
       break;
@@ -31,7 +33,7 @@ export default function UserActionButton({ page, userId, study }: UserActionButt
       userStatus = "APPLIED";
       userAction = deleteMember;
       break;
-    case studyData.status === "RECURIT_END" || studyData.status === "PROGRESS" || studyData.status === "DONE":
+    case studyData?.status === "RECURIT_END" || studyData?.status === "PROGRESS" || studyData?.status === "DONE":
       userStatus = "RECRUIT_END";
       userAction = undefined;
     default:
@@ -43,21 +45,25 @@ export default function UserActionButton({ page, userId, study }: UserActionButt
 
   const goToApplyPage = () => {
     if (userStatus === "NOT_APPLIED") {
-      router.push("/"); // 지원서 작성 페이지로 연결
+      router.push(`/study/${id}/apply`); // 지원서 작성 페이지로 연결, 스터디 아이디 가져가야함
     }
+  };
+
+  const recruitStudy = () => {
+    router.push(`/recruit?lectureId=${id}`); //강의 아이디 저장해서 모집할때 써야함
   };
 
   return (
     <>
       <form action={userAction} className="w-full">
-        <input hidden name="studyId" defaultValue={studyData._id} />
+        <input hidden name="studyId" defaultValue={studyData?._id} />
         <input hidden name="memberId" defaultValue={teamMemberInfo?.memberId} />
         <Button
           type={userStatus === "NOT_APPLIED" ? "button" : "submit"}
           varient="filled"
           addStyle="bg-main-500 w-full h-[50px] text-white rounded-[5px]"
           disabled={buttonConfig.disabled}
-          onClick={goToApplyPage}>
+          onClick={page === "study" ? goToApplyPage : recruitStudy}>
           {buttonConfig.text}
         </Button>
       </form>

--- a/src/components/domains/detail/lecture/LectureRelatedStudies.tsx
+++ b/src/components/domains/detail/lecture/LectureRelatedStudies.tsx
@@ -2,30 +2,40 @@ import Button from "@/components/commons/Button";
 import { StudyRecruitCard } from "../../../commons/card/StudyRecruitCard";
 import CardList from "../../../commons/CardList";
 import Title from "../Title";
-import { TRelatedStudy } from "@/types/api/lecture";
+import { TStudyRecruitCardData } from "@/types/api/study";
+import NoResultText from "@/components/commons/NoResultText";
+import Link from "next/link";
 
 interface LectureRelatedStudiesProps {
-  relatedStudyList: TRelatedStudy[];
+  relatedStudyList: TStudyRecruitCardData[];
 }
 
 export default function LectureRelatedStudies({ relatedStudyList }: LectureRelatedStudiesProps) {
   return (
     <>
-      {relatedStudyList.length !== 0 && (
-        <section className="mb-[50px]">
-          <Title addStyle="mb-5">
-            이 강의를 수강하는 스터디 <span className="text-main-500 ">{relatedStudyList.length}개</span>
-          </Title>
-          <CardList>
-            {/* {relatedStudyList.slice(0, 4).map((study) => (
-              // <StudyRecruitCard key={study._id} isMini isScraped />
-            ))} */}
-          </CardList>
-          <Button varient="ghost" addStyle="w-full h-[50px] rounded-[5px] border-gray-400 text-gray-800 mt-6">
-            스터디 전체보기
-          </Button>
-        </section>
-      )}
+      <section className="mb-[50px]">
+        <Title addStyle="mb-5">
+          이 강의를 수강하는 스터디 <span className="text-main-500 ">{relatedStudyList.length}개</span>
+        </Title>
+        {relatedStudyList.length !== 0 ? (
+          <>
+            <CardList>
+              {relatedStudyList.slice(0, 4).map((study) => (
+                <Link href={`/study/${study.id}`}>
+                  <StudyRecruitCard key={study.id} isMini isScraped={false} recruitCardData={study} />
+                </Link>
+              ))}
+            </CardList>
+            {relatedStudyList.length > 4 && (
+              <Button varient="ghost" addStyle="w-full h-[50px] rounded-[5px] border-gray-400 text-gray-800 mt-6">
+                스터디 전체보기
+              </Button>
+            )}
+          </>
+        ) : (
+          <NoResultText>해당 강의를 수강하는 스터디가 없습니다.</NoResultText>
+        )}
+      </section>
     </>
   );
 }

--- a/src/components/domains/home/Contents.tsx
+++ b/src/components/domains/home/Contents.tsx
@@ -137,7 +137,7 @@ export default function Contents() {
             TopSectionStudyList.map((study) => (
               <StudyRecruitCard
                 key={study.id}
-                RecruitCardData={study}
+                recruitCardData={study}
                 onClick={() => {
                   router.push(`/study/${study.id}`);
                 }}
@@ -164,7 +164,7 @@ export default function Contents() {
             BottomSectionStudyList.map((study) => (
               <StudyRecruitCard
                 key={study.id}
-                RecruitCardData={study}
+                recruitCardData={study}
                 onClick={() => {
                   router.push(`/study/${study.id}`);
                 }}

--- a/src/components/domains/search/result/Content.tsx
+++ b/src/components/domains/search/result/Content.tsx
@@ -80,7 +80,7 @@ export default function Content() {
                     studyList.slice(0, 4).map((study: TStudyRecruitCardData) => (
                       <div key={study.id} className="w-full">
                         <StudyRecruitCard
-                          RecruitCardData={study}
+                          recruitCardData={study}
                           onClick={() => {
                             router.push(`/study/${study.id}`);
                           }}
@@ -92,7 +92,7 @@ export default function Content() {
                   ) : (
                     studyList.map((study: TStudyRecruitCardData) => (
                       <StudyRecruitCard
-                        RecruitCardData={study}
+                        recruitCardData={study}
                         onClick={() => {
                           router.push(`/study/${study.id}`);
                         }}

--- a/src/types/api/lecture.ts
+++ b/src/types/api/lecture.ts
@@ -1,4 +1,4 @@
-import { TCategory, TStudyDetailInfoData } from "./study";
+import { TCategory, TStudyDetailInfoData, TStudyRecruitCardData } from "./study";
 
 export type TLectureInfoData = {
   _id: string;
@@ -27,7 +27,7 @@ export type TRelatedStudy = TStudyDetailInfoData;
 
 export type TLectureDetailData = {
   lecture: TLectureInfoData;
-  relatedStudyList: TRelatedStudy[];
+  relatedStudyList: TStudyRecruitCardData[];
 };
 
 export type TLectureListCardData = {

--- a/src/types/api/study.ts
+++ b/src/types/api/study.ts
@@ -13,7 +13,7 @@ export type TCategory =
   | "SELF-DEVELOPMENT";
 
 export type TTeamMember = {
-  memberId: mongoose.Types.ObjectId;
+  memberId: string;
   nickname: string;
   profileImageUrl: string;
   role: TRole;


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 스크린샷

https://github.com/user-attachments/assets/e8497d3e-c0b7-40c1-b216-daef07e42329




https://github.com/user-attachments/assets/48a7342f-3017-4f54-b011-17daa5d916b0




## 구현 사항 설명
강의 상세페이지의 관련된 스터디들, 매칭  성공시 보여주는 스터디 카드  api 연결 (마이페이지 북마크된 스터디목록 제외),
강의상세페이지, 스터디상세페이지 지원하기 모집하기 버튼 연결 이제 이동 됩니다. 
강의상세페이지에서 스터디 모집 할 경우 searchParams로 강의 아이디 전달합니다~