### PR TITLE
Feat: 내 스터디 리스트, 지원서 리스트 4차

### DIFF
--- a/src/app/api/my-study/list/route.ts
+++ b/src/app/api/my-study/list/route.ts
@@ -1,4 +1,5 @@
 import connectDB from "@/lib/database/db";
+import { Application } from "@/schema/applicationSchema";
 import { Study } from "@/schema/studySchema";
 import { TeamMembers } from "@/schema/teamMemberSchema";
 
@@ -102,11 +103,30 @@ export async function GET(request: Request) {
           status: "RECRUIT_START",
         }).populate({
           path: "teamMembersId",
-          select: "members",
+          model: "TeamMembers",
+          select: {
+            members: {
+              $elemMatch: { userId: userId },
+            },
+          },
         });
 
+        const enhancedStudyList = await Promise.all(
+          studyList.map(async (study) => {
+            // 내 지원서 id 추출
+            const myApplicationId = study.teamMembersId.members[0].applicationId;
+            // 지원서 생성일 조회
+            const application = await Application.findById({ _id: myApplicationId }, { createdAt: 1 });
+            return {
+              ...study.toObject(), // 스터디
+              applicationCreatedAt: application.createdAt, // 필드 추가
+            };
+          }),
+        );
+
+        console.log(enhancedStudyList);
         return Response.json({
-          recruitStartMemberStudyList: studyList,
+          recruitStartMemberStudyList: enhancedStudyList,
           recruitStartOwnerStudyListCount: await Study.countDocuments({
             ownerId: userId,
             status: "RECRUIT_START",

--- a/src/app/api/my-study/list/route.ts
+++ b/src/app/api/my-study/list/route.ts
@@ -124,7 +124,6 @@ export async function GET(request: Request) {
           }),
         );
 
-        console.log(enhancedStudyList);
         return Response.json({
           recruitStartMemberStudyList: enhancedStudyList,
           recruitStartOwnerStudyListCount: await Study.countDocuments({

--- a/src/components/commons/card/StudyApplicationCard.tsx
+++ b/src/components/commons/card/StudyApplicationCard.tsx
@@ -5,14 +5,17 @@ import StudyCardLink from "./element/StudyCardLink";
 import { getFirstInterestLevel } from "@/utils/getFirstInterestLevel";
 import { CATEGORY } from "@/constant/category";
 import { CAREER_LIST } from "@/constant/teamMemberInfo";
+import { format } from "date-fns";
 
 export default function StudyApplicationCard(props: TApplicationSummary) {
-  const { profileImageUrl, status, nickname, title, levels } = props;
+  const { profileImageUrl, status, nickname, title, levels, createdAt } = props;
   const { interest, level } = getFirstInterestLevel(levels.levels);
+
+  const applicationCreatedAt = createdAt ? `${format(new Date(createdAt), "yyyy.MM.dd HH:mm")} 지원` : "";
 
   return (
     <article className="flex flex-col gap-4 px-5 py-6 bg-white border border-gray-300 rounded-lg">
-      <StudyApplyInfo status={status} />
+      <StudyApplyInfo status={status} createAt={applicationCreatedAt} />
 
       <section className="flex items-center justify-stretch gap-3">
         <Avatar width={40} height={40} profileImageUrl={profileImageUrl} hasBorder={true} />

--- a/src/components/commons/card/StudyApplyingCard.tsx
+++ b/src/components/commons/card/StudyApplyingCard.tsx
@@ -3,8 +3,8 @@ import StudyApplyInfo from "./element/StudyApplyInfo";
 import StudyCardButton from "./element/StudyCardButton";
 import StudyMeetingInfo from "./element/StudyMeetingInfo";
 import { getDateRange } from "@/utils/getDateRange";
-import { getSession } from "@/lib/database/getSession";
 import Link from "next/link";
+import { format } from "date-fns";
 
 interface IStudyApplyingCardProps {
   study: TMyStudy;
@@ -19,28 +19,27 @@ export default async function StudyApplyingCard(props: IStudyApplyingCardProps) 
       endDate,
       meeting: {
         schedule: { day },
-        format,
+        format: meetingFormat,
         platform,
         location,
       },
       teamMembersId,
+      applicationCreatedAt,
     },
   } = props;
 
-  const session = await getSession();
-  const userId = session?.user?.id;
-
   const dateRange = getDateRange(startDate, endDate);
-  const where = (format === "ONLINE" ? platform : location) ?? "";
-  const status = (teamMembersId as TTeamMembersIdAddedMember)?.members?.find(
-    (member) => member.userId.toString() === userId,
-  )?.status;
+  const where = (meetingFormat === "ONLINE" ? platform : location) ?? "";
+  const status = (teamMembersId as TTeamMembersIdAddedMember)?.members?.[0].status;
+  const myApplicationCreatedAt = applicationCreatedAt
+    ? `${format(new Date(applicationCreatedAt), "yyyy.MM.dd HH:mm")} 지원`
+    : "";
 
   return (
     <Link
       className="flex flex-col gap-4 px-5 py-6 bg-white border border-gray-300 rounded-lg"
       href={`/study/${studyId}`}>
-      {status && <StudyApplyInfo status={status} />}
+      {status && <StudyApplyInfo status={status} createAt={myApplicationCreatedAt} />}
       <StudyMeetingInfo format={"ONLINE" ? "온라인" : "오프라인"} dateRange={dateRange} where={where} />
       <p className="text-[#212121] text-[16px] font-semibold tracking-[-0.32px]">{title}</p>
       <hr className="bg-gray-300" />

--- a/src/components/commons/card/StudyOnGoingCard.tsx
+++ b/src/components/commons/card/StudyOnGoingCard.tsx
@@ -32,9 +32,12 @@ export default function StudyOnGoingCard(props: IStudyOnGoingCardProps) {
   const dateRange = getDateRange(startDate, endDate);
   const where = (format === "ONLINE" ? platform : location) ?? "";
   const meetingDay = `매주 ${day}`;
-  const memberCount = (teamMembersId as TTeamMembersIdAddedMember)?.members?.filter(
-    (member) => member.status === "ACCEPTED",
-  )?.length;
+  const memberCountAccepted = (teamMembersId as TTeamMembersIdAddedMember)?.members
+    ?.filter((member) => member.status === "ACCEPTED")
+    ?.length.toString();
+
+  const memberCountWanted = props?.study?.wantedMember?.count;
+
   return (
     <Link
       href={`/study/${studyId}/dashboard`}
@@ -44,7 +47,11 @@ export default function StudyOnGoingCard(props: IStudyOnGoingCardProps) {
       <StudyMeetingInfo format={"ONLINE" ? "온라인" : "오프라인"} dateRange={dateRange} where={where} />
       <p className="mt-2 text-gray-1000 text-[16px] font-semibold tracking-[-0.32px]">{title}</p>
       <hr className="my-4" />
-      <StudyDetailInfo meetingDay={meetingDay} task={getMeetingInfoTaskText(task)} memberCount={memberCount} />
+      <StudyDetailInfo
+        meetingDay={meetingDay}
+        task={getMeetingInfoTaskText(task)}
+        memberCount={memberCountWanted ? `${memberCountAccepted}/${memberCountWanted}` : memberCountAccepted}
+      />
     </Link>
   );
 }

--- a/src/components/commons/card/StudyRecruitingCard.tsx
+++ b/src/components/commons/card/StudyRecruitingCard.tsx
@@ -31,9 +31,11 @@ export default function StudyRecruitingCard(props: IStudyRecruitingCardProps) {
   const dateRange = getDateRange(startDate, endDate);
   const where = (format === "ONLINE" ? platform : location) ?? "";
   const meetingDay = `매주 ${day}`;
-  const memberCount = (teamMembersId as TTeamMembersIdAddedMember)?.members?.filter(
-    (member) => member.status === "ACCEPTED",
-  )?.length;
+  const memberCountAccepted = (teamMembersId as TTeamMembersIdAddedMember)?.members
+    ?.filter((member) => member.status === "ACCEPTED")
+    ?.length.toString();
+  const memberCountWanted = props?.study?.wantedMember?.count;
+
   return (
     <div className="py-6 px-5 border border-gray-300 bg-white rounded-lg">
       <Link href={`/study/${studyId}`}>
@@ -44,7 +46,7 @@ export default function StudyRecruitingCard(props: IStudyRecruitingCardProps) {
           className="mb-4"
           meetingDay={meetingDay}
           task={getMeetingInfoTaskText(task)}
-          memberCount={memberCount}
+          memberCount={memberCountWanted ? `${memberCountAccepted}/${memberCountWanted}` : memberCountAccepted}
         />
       </Link>
       <StudyCardLink href={`/application-list/${studyId}`}>지원서 리스트 보기</StudyCardLink>

--- a/src/components/commons/card/element/StudyApplyInfo.tsx
+++ b/src/components/commons/card/element/StudyApplyInfo.tsx
@@ -1,5 +1,6 @@
 interface IStudyApplyInfoProps {
   status: "APPLIED" | "APPLIED_VIEW" | "ACCEPTED";
+  createAt: string;
 }
 
 interface IApplyStatusProps {
@@ -22,11 +23,11 @@ const APPLY_STATUS_TYPE = {
   },
 };
 
-export default function StudyApplyInfo({ status }: IStudyApplyInfoProps) {
+export default function StudyApplyInfo({ status, createAt }: IStudyApplyInfoProps) {
   return (
     <section className="flex justify-between">
       <ApplyStatus status={status} />
-      <span className="text-main-400 text-[12px] font-normal tracking-[-0.36px]">{"2024.06.15 14:30 지원"}</span>
+      <span className="text-main-400 text-[12px] font-normal tracking-[-0.36px]">{createAt}</span>
     </section>
   );
 }

--- a/src/components/commons/card/element/StudyDetailInfo.tsx
+++ b/src/components/commons/card/element/StudyDetailInfo.tsx
@@ -4,7 +4,7 @@ import { teammate, schedule, checkSquare } from "@/../public/icons/icons";
 interface IStudyDetailInfoProps {
   className?: string;
   meetingDay: string;
-  memberCount: number;
+  memberCount: string;
   task: string;
 }
 export function StudyDetailInfo(props: IStudyDetailInfoProps) {

--- a/src/schema/applicationSchema.ts
+++ b/src/schema/applicationSchema.ts
@@ -1,26 +1,28 @@
 import mongoose from "mongoose";
 
-const applicationSchema = new mongoose.Schema({
-  // applicationId는 몽고DB에서 주는 걸로
-  studyId: { type: mongoose.Schema.Types.ObjectId, ref: "Study", required: true },
-  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-  title: { type: String, required: true },
-  resolution: { type: String, required: true },
-  role: {
-    type: String,
-    enum: [
-      "leader",
-      "viceLeader",
-      "assignment",
-      "notification",
-      "attendance",
-      "record",
-      "environment",
-      "schedule",
-      "member",
-    ],
-    required: true,
+const applicationSchema = new mongoose.Schema(
+  {
+    studyId: { type: mongoose.Schema.Types.ObjectId, ref: "Study", required: true },
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    title: { type: String, required: true },
+    resolution: { type: String, required: true },
+    role: {
+      type: String,
+      enum: [
+        "leader",
+        "viceLeader",
+        "assignment",
+        "notification",
+        "attendance",
+        "record",
+        "environment",
+        "schedule",
+        "member",
+      ],
+      required: true,
+    },
   },
-});
+  { timestamps: true },
+);
 
 export const Application = mongoose.models.Application || mongoose.model("Application", applicationSchema);

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -26,6 +26,7 @@ export type TApplication = {
     _id: Types.ObjectId;
     levels: string;
   };
+  createdAt?: Date;
 };
 
 export type TApplicationSummary = Omit<TApplication, "resolution" | "role">;

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -112,6 +112,7 @@ export type TMyStudy = {
   scrapCount?: number;
   wantedMember: TWantedMember;
   __v?: number;
+  applicationCreatedAt?: Date;
 };
 
 export type TTeamMembersIdAddedMember = {

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -53,13 +53,20 @@ export type UserFavoriteFieldType = {
   freewheeling: StudyCategory;
 };
 
+export type TWantedMember = {
+  career: string[];
+  count: string;
+  age: string[];
+  role: string[];
+};
+
 export type TMyStudy = {
   _id: mongoose.Types.ObjectId;
   category: "DESIGN" | "DEVELOP" | "BUSINESS" | "MARKETING" | "ECONOMY" | "LANGUAGE" | "LICENSE" | "SELF-DEVELOPMENT";
   ownerId: mongoose.Types.ObjectId;
   lectureId: mongoose.Types.ObjectId;
   title: string;
-  imageUrl: string;
+  imageUrl: string | null;
   description: string;
   meeting: {
     schedule: {
@@ -102,6 +109,9 @@ export type TMyStudy = {
   teamMembersId?: mongoose.Types.ObjectId | TTeamMembersIdAddedMember;
   createdAt: Date;
   updatedAt: Date;
+  scrapCount?: number;
+  wantedMember: TWantedMember;
+  __v?: number;
 };
 
 export type TTeamMembersIdAddedMember = {


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정

## 스크린 샷
<img width="601" alt="image" src="https://github.com/user-attachments/assets/2ad1d148-d223-4eee-8f50-4f0f8f05cbbd">
<img width="601" alt="image" src="https://github.com/user-attachments/assets/a78d1958-0779-4fa6-9c7f-7559a12e3c69">

## 구현 사항 설명
- [x] 지원서 스키마에 타임스탬프 추가
- [x] 지원 중 스터디 카드와 지원서 목록에 타임스탬프 연동
- [x] 진행 중, 진행 예정, 모집 중 스터디 카드에 팀원 수 `확정 멤버 수 / 모집 희망 멤버 수`로 개선

close #115