### PR TITLE
Feat: 내 스터디 페이지, 대시보드 페이지 QA

### DIFF
--- a/src/app/(userProfile)/mypage/scrap/layout.tsx
+++ b/src/app/(userProfile)/mypage/scrap/layout.tsx
@@ -26,7 +26,7 @@ export default function ScrapLayout({ params, tabs }: IDashboardProps) {
       <TopBar variant="back">관심 목록</TopBar>
 
       {/* Tab Menu */}
-      <TabBarLinkUnderlined defaultSegment={hrefBase} tabMenuList={SCRAP_TAB_MENU_LIST} />
+      <TabBarLinkUnderlined defaultSegment={hrefBase} tabMenuList={SCRAP_TAB_MENU_LIST} isReplace={true} />
 
       {/* Tab Panel */}
       {tabs}

--- a/src/app/api/dashboard/is-member/route.ts
+++ b/src/app/api/dashboard/is-member/route.ts
@@ -1,0 +1,25 @@
+import connectDB from "@/lib/database/db";
+import { TeamMembers } from "@/schema/teamMemberSchema";
+
+export async function GET(request: Request) {
+  connectDB();
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId");
+    const studyId = searchParams.get("studyId");
+    if (!userId) return Response.json(false);
+    if (!studyId) return Response.json(false);
+
+    // 내가 해당 스터디의 멤버인지
+    const teamMember = await TeamMembers.findOne({
+      studyId,
+      "members.userId": userId,
+      "members.status": "ACCEPTED",
+    });
+
+    return Response.json(teamMember !== null);
+  } catch (error: any) {
+    throw new Error(error);
+  }
+}

--- a/src/app/api/my-study/list/count/route.ts
+++ b/src/app/api/my-study/list/count/route.ts
@@ -11,7 +11,6 @@ export async function GET(request: Request) {
   try {
     const teamMembers = await TeamMembers.find({
       "members.userId": userId,
-      $or: [{ "members.isOwner": true }, { "members.status": "ACCEPTED" }],
     });
     const studyIdList = teamMembers.map((member) => member.studyId);
     const [progressCount, waitingCount, doneCount] = await Promise.all([

--- a/src/app/api/my-study/list/route.ts
+++ b/src/app/api/my-study/list/route.ts
@@ -15,10 +15,19 @@ export async function GET(request: Request) {
        * PROGRESS, RECRUIT_END, DOME : 내가 참여하고 있는 모든 스터디 (개설 or 지원 후 ACCEPTED) 중 각 status로 필터링한 목록 조회
        */
       case "PROGRESS": {
-        const teamMembers = await TeamMembers.find({
+        const teamMembersOwnerPromise = TeamMembers.find({
           "members.userId": userId,
-          $or: [{ "members.isOwner": true }, { "members.status": "ACCEPTED" }],
-        });
+          "members.isOwner": true,
+        }).exec();
+        const teamMembersAcceptedPromise = TeamMembers.find({
+          "members.userId": userId,
+          "members.status": "ACCEPTED",
+        }).exec();
+        const [teamMembersOwner, teamMembersAccepted] = await Promise.all([
+          teamMembersOwnerPromise,
+          teamMembersAcceptedPromise,
+        ]);
+        const teamMembers = [...teamMembersOwner, teamMembersAccepted];
         const studyIdList = teamMembers.map((member) => member.studyId);
         const studyList = await Study.find({
           _id: { $in: studyIdList },
@@ -37,10 +46,19 @@ export async function GET(request: Request) {
       }
 
       case "RECRUIT_END": {
-        const teamMembers = await TeamMembers.find({
+        const teamMembersOwnerPromise = TeamMembers.find({
           "members.userId": userId,
-          $or: [{ "members.isOwner": true }, { "members.status": "ACCEPTED" }],
-        });
+          "members.isOwner": true,
+        }).exec();
+        const teamMembersAcceptedPromise = TeamMembers.find({
+          "members.userId": userId,
+          "members.status": "ACCEPTED",
+        }).exec();
+        const [teamMembersOwner, teamMembersAccepted] = await Promise.all([
+          teamMembersOwnerPromise,
+          teamMembersAcceptedPromise,
+        ]);
+        const teamMembers = [...teamMembersOwner, teamMembersAccepted];
         const studyIdList = teamMembers.map((member) => member.studyId);
         const studyList = await Study.find({
           _id: { $in: studyIdList },
@@ -134,10 +152,19 @@ export async function GET(request: Request) {
       }
 
       case "DONE": {
-        const teamMembers = await TeamMembers.find({
+        const teamMembersOwnerPromise = TeamMembers.find({
           "members.userId": userId,
-          $or: [{ "members.isOwner": true }, { "members.status": "ACCEPTED" }],
-        });
+          "members.isOwner": true,
+        }).exec();
+        const teamMembersAcceptedPromise = TeamMembers.find({
+          "members.userId": userId,
+          "members.status": "ACCEPTED",
+        }).exec();
+        const [teamMembersOwner, teamMembersAccepted] = await Promise.all([
+          teamMembersOwnerPromise,
+          teamMembersAcceptedPromise,
+        ]);
+        const teamMembers = [...teamMembersOwner, teamMembersAccepted];
         const studyIdList = teamMembers.map((member) => member.studyId);
         const studyList = await Study.find({
           _id: { $in: studyIdList },

--- a/src/app/api/my-study/meeting/route.ts
+++ b/src/app/api/my-study/meeting/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
       },
       { meeting: 1, startDate: 1, endDate: 1, title: 1 },
     );
-    // 2) 모든 스터디의 7일 내 미팅으로 리스트 생성
+    // 2) 모든 스터디의 14일 내 미팅으로 리스트 생성
     let upcomingMeetingList: TUpcomingMeetingList = [];
     studyList.forEach((study) => {
       const {
@@ -38,7 +38,6 @@ export async function GET(request: Request) {
           schedule: { time, day },
           location,
         },
-        startDate,
         endDate,
         title,
       } = study;
@@ -46,12 +45,14 @@ export async function GET(request: Request) {
       const where = format === "ONLINE" ? platform : location;
       const meetingInfo = {
         title,
-        startDate,
         endDate,
         where,
         day,
         time,
       };
+
+      console.log("studyList", meetingInfo);
+
       upcomingMeetingList = [...upcomingMeetingList, ...generateUpcomingMeetingList(meetingInfo)].sort(
         (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
       );

--- a/src/app/study/[id]/dashboard/@tabs/me/page.tsx
+++ b/src/app/study/[id]/dashboard/@tabs/me/page.tsx
@@ -23,5 +23,5 @@ export default async function MeTab(props: IMeTabProps) {
 }
 
 function getExtractDateList(data: any) {
-  return data.map((item: any) => new Date(item.date));
+  return data?.map((item: any) => new Date(item.date));
 }

--- a/src/app/study/[id]/dashboard/@tabs/me/page.tsx
+++ b/src/app/study/[id]/dashboard/@tabs/me/page.tsx
@@ -1,6 +1,8 @@
 import CalendarCard from "@/components/domains/dashboard/CalendarCard";
 import ChecklistCard from "@/components/domains/dashboard/ChecklistCard";
+import NoList from "@/components/domains/mystudy/NoList";
 import { fetchMyCheckListAction } from "@/lib/database/action/dashboard";
+import { getSession } from "@/lib/database/getSession";
 
 interface IMeTabProps {
   params: {
@@ -8,8 +10,32 @@ interface IMeTabProps {
   };
 }
 
+const getIsMember = async (userId: string | undefined, studyId: string) => {
+  try {
+    if (!userId) return false;
+    const response = await fetch(
+      `${process.env.LOCAL_URL}/api/dashboard/is-member?userId=${userId}&studyId=${studyId}`,
+    );
+
+    return await response.json();
+  } catch (error) {
+    console.error("Error fetching", error);
+    throw error;
+  }
+};
+
 export default async function MeTab(props: IMeTabProps) {
   const studyId = props.params.id;
+  const session = await getSession();
+  const myUserId = session?.user?.id;
+  const isMember = await getIsMember(myUserId, studyId);
+  if (!isMember)
+    return (
+      <section className="flex flex-col gap-3 pt-6 py-10 px-4">
+        <NoList>이 스터디의 멤버만 확인할 수 있습니다.</NoList>
+      </section>
+    );
+
   const myCheckList = await fetchMyCheckListAction(studyId);
   const { data: checkListData } = myCheckList; // checkList.list.[].data
   const dateList = getExtractDateList(checkListData);

--- a/src/app/study/[id]/dashboard/@tabs/page.tsx
+++ b/src/app/study/[id]/dashboard/@tabs/page.tsx
@@ -29,7 +29,7 @@ export default async function TeamTab(props: ITeamTabProps) {
   const studyId = props.params.id;
 
   const session = await getSession();
-  const userId = session?.user?.id;
+  const myUserId = session?.user?.id;
 
   const { dashboard, teamMemberList, ownerId, study } = await getDashboardInfo(studyId);
 
@@ -42,7 +42,7 @@ export default async function TeamTab(props: ITeamTabProps) {
     endDate: study.endDate,
   });
 
-  const isOwner = userId === ownerId;
+  const isOwner = myUserId === ownerId;
   const isProgressGaugeExist = progressGauge.isActive;
   const isAttendanceExist = attendance.isActive;
   const isCheckListExist = checkList.isActive;
@@ -83,7 +83,7 @@ export default async function TeamTab(props: ITeamTabProps) {
         {/* {isProofListExist && <StudyPhotoProof />} */}
       </div>
 
-      {isAnyFeatureNotExist && (
+      {isOwner && isAnyFeatureNotExist && (
         <div className="flex flex-col gap-4 mt-4">
           {!isProgressGaugeExist && (
             <form action={toggleFunctionIsActive}>

--- a/src/app/study/[id]/dashboard/@tabs/page.tsx
+++ b/src/app/study/[id]/dashboard/@tabs/page.tsx
@@ -14,7 +14,7 @@ const getDashboardInfo = async (id: string) => {
     const response = await fetch(`${process.env.LOCAL_URL}/api/dashboard?studyId=${id}`);
     return await response.json();
   } catch (error) {
-    console.error("Error fetching study", error);
+    console.error("Error fetching", error);
     throw error;
   }
 };

--- a/src/app/study/[id]/dashboard/layout.tsx
+++ b/src/app/study/[id]/dashboard/layout.tsx
@@ -1,4 +1,3 @@
-import Gnb from "@/components/commons/Gnb";
 import TabBarLinkUnderlined from "@/components/commons/TabBarLinkUnderlined";
 import TopBar from "@/components/commons/TopBar";
 import StudyInfo from "@/components/domains/dashboard/StudyInfo";
@@ -11,17 +10,24 @@ interface IDashboardProps {
   tabs: React.ReactNode;
 }
 
-export default function DashboardLayout({ params, tabs }: IDashboardProps) {
+export default async function DashboardLayout({ params, tabs }: IDashboardProps) {
   const { id } = params;
 
   const hrefBase = `/study/${id}/dashboard/`;
 
-  const MY_STUDY_DASHBOARD_TAB_MENU_LIST: TTabMenuLinkUnderlinedItem[] = [
+  const MY_STUDY_DASHBOARD_TAB_MENU_LIST_FOR_MEMBER: TTabMenuLinkUnderlinedItem[] = [
     { id: "team", title: "팀", href: `${hrefBase}` },
     { id: "me", title: "개인", href: `${hrefBase}me` },
     { id: "schedule", title: "일정", href: `${hrefBase}schedule` },
     { id: "board", title: "게시판", href: `${hrefBase}board` },
   ];
+
+  // const MY_STUDY_DASHBOARD_TAB_MENU_LIST_FOR_OTHERS: TTabMenuLinkUnderlinedItem[] = [
+  //   { id: "team", title: "팀", href: `${hrefBase}` },
+  //   { id: "me", title: "개인", href: `${hrefBase}me` },
+  //   { id: "schedule", title: "일정", href: `${hrefBase}schedule` },
+  //   { id: "board", title: "게시판", href: `${hrefBase}board` },
+  // ];
 
   const bg = `bg-[linear-gradient(0deg,#151515_0%,rgba(21,21,21,0.50)_100%),url('https://picsum.photos/200/300')]`;
 
@@ -31,15 +37,14 @@ export default function DashboardLayout({ params, tabs }: IDashboardProps) {
         {/* Header */}
         <div className={`relative bg-no-repeat bg-cover bg-top ${bg}`}>
           {/* TODO 공통 레이아웃 처리 */}
-          <Gnb />
-          <TopBar variant="share" showMore={false} isWhite={true} />
+          <TopBar variant="share" showMore={false} isWhite={true} isBackToHome />
           {/* Study Info */}
           <StudyInfo params={id} />
         </div>
         {/* Tab Menu */}
         <TabBarLinkUnderlined
           defaultSegment={hrefBase}
-          tabMenuList={MY_STUDY_DASHBOARD_TAB_MENU_LIST}
+          tabMenuList={MY_STUDY_DASHBOARD_TAB_MENU_LIST_FOR_MEMBER}
           stickyOption="sticky top-0 z-[2]"
         />
         {/* Tab Panel */}

--- a/src/app/study/[id]/dashboard/layout.tsx
+++ b/src/app/study/[id]/dashboard/layout.tsx
@@ -39,6 +39,7 @@ export default async function DashboardLayout({ params, tabs }: IDashboardProps)
           defaultSegment={hrefBase}
           tabMenuList={MY_STUDY_DASHBOARD_TAB_MENU_LIST}
           stickyOption="sticky top-0 z-[2]"
+          isReplace={true}
         />
         {/* Tab Panel */}
         {tabs}

--- a/src/app/study/[id]/dashboard/layout.tsx
+++ b/src/app/study/[id]/dashboard/layout.tsx
@@ -15,19 +15,12 @@ export default async function DashboardLayout({ params, tabs }: IDashboardProps)
 
   const hrefBase = `/study/${id}/dashboard/`;
 
-  const MY_STUDY_DASHBOARD_TAB_MENU_LIST_FOR_MEMBER: TTabMenuLinkUnderlinedItem[] = [
+  const MY_STUDY_DASHBOARD_TAB_MENU_LIST: TTabMenuLinkUnderlinedItem[] = [
     { id: "team", title: "팀", href: `${hrefBase}` },
     { id: "me", title: "개인", href: `${hrefBase}me` },
     { id: "schedule", title: "일정", href: `${hrefBase}schedule` },
     { id: "board", title: "게시판", href: `${hrefBase}board` },
   ];
-
-  // const MY_STUDY_DASHBOARD_TAB_MENU_LIST_FOR_OTHERS: TTabMenuLinkUnderlinedItem[] = [
-  //   { id: "team", title: "팀", href: `${hrefBase}` },
-  //   { id: "me", title: "개인", href: `${hrefBase}me` },
-  //   { id: "schedule", title: "일정", href: `${hrefBase}schedule` },
-  //   { id: "board", title: "게시판", href: `${hrefBase}board` },
-  // ];
 
   const bg = `bg-[linear-gradient(0deg,#151515_0%,rgba(21,21,21,0.50)_100%),url('https://picsum.photos/200/300')]`;
 
@@ -44,7 +37,7 @@ export default async function DashboardLayout({ params, tabs }: IDashboardProps)
         {/* Tab Menu */}
         <TabBarLinkUnderlined
           defaultSegment={hrefBase}
-          tabMenuList={MY_STUDY_DASHBOARD_TAB_MENU_LIST_FOR_MEMBER}
+          tabMenuList={MY_STUDY_DASHBOARD_TAB_MENU_LIST}
           stickyOption="sticky top-0 z-[2]"
         />
         {/* Tab Panel */}

--- a/src/app/study/[id]/dashboard/layout.tsx
+++ b/src/app/study/[id]/dashboard/layout.tsx
@@ -1,3 +1,4 @@
+import Gnb from "@/components/commons/Gnb";
 import TabBarLinkUnderlined from "@/components/commons/TabBarLinkUnderlined";
 import TopBar from "@/components/commons/TopBar";
 import StudyInfo from "@/components/domains/dashboard/StudyInfo";
@@ -25,22 +26,25 @@ export default function DashboardLayout({ params, tabs }: IDashboardProps) {
   const bg = `bg-[linear-gradient(0deg,#151515_0%,rgba(21,21,21,0.50)_100%),url('https://picsum.photos/200/300')]`;
 
   return (
-    <section className="min-h-dvh bg-gray-100">
-      <div className={`relative bg-no-repeat bg-cover bg-top ${bg}`}>
+    <>
+      <section className="min-h-dvh bg-gray-100">
         {/* Header */}
-        {/* TODO 공통 레이아웃 처리 */}
-        <TopBar variant="share" showMore={false} isWhite={true} />
-        {/* Study Info */}
-        <StudyInfo params={id} />
-      </div>
-      {/* Tab Menu */}
-      <TabBarLinkUnderlined
-        defaultSegment={hrefBase}
-        tabMenuList={MY_STUDY_DASHBOARD_TAB_MENU_LIST}
-        stickyOption="sticky top-0 z-[2]"
-      />
-      {/* Tab Panel */}
-      {tabs}
-    </section>
+        <div className={`relative bg-no-repeat bg-cover bg-top ${bg}`}>
+          {/* TODO 공통 레이아웃 처리 */}
+          <Gnb />
+          <TopBar variant="share" showMore={false} isWhite={true} />
+          {/* Study Info */}
+          <StudyInfo params={id} />
+        </div>
+        {/* Tab Menu */}
+        <TabBarLinkUnderlined
+          defaultSegment={hrefBase}
+          tabMenuList={MY_STUDY_DASHBOARD_TAB_MENU_LIST}
+          stickyOption="sticky top-0 z-[2]"
+        />
+        {/* Tab Panel */}
+        {tabs}
+      </section>
+    </>
   );
 }

--- a/src/components/commons/DetailTabMenu.tsx
+++ b/src/components/commons/DetailTabMenu.tsx
@@ -41,6 +41,7 @@ export default function DetailTabMenu({ type }: IDetailTabMenuLinkUnderlinedProp
           isCurrent={currentTab === tab.href}
           href={tab.href}
           onClick={() => handleClick(tab.href)}
+          isReplace={true}
         />
       ))}
     </nav>

--- a/src/components/commons/TabBarLinkUnderlined.tsx
+++ b/src/components/commons/TabBarLinkUnderlined.tsx
@@ -10,10 +10,11 @@ interface ITabBarUnderlined {
   defaultSegment: string;
   tabMenuList: TTabMenuLinkUnderlinedItem[];
   stickyOption?: string;
+  isReplace?: boolean;
 }
 
 export default function TabBarLinkUnderlined(props: ITabBarUnderlined) {
-  const { defaultSegment, tabMenuList, stickyOption } = props;
+  const { defaultSegment, tabMenuList, stickyOption, isReplace } = props;
   const currentTab = useSelectedLayoutSegment("tabs") ?? "";
 
   return (
@@ -22,6 +23,7 @@ export default function TabBarLinkUnderlined(props: ITabBarUnderlined) {
         <TabMenuLinkUnderlined
           key={item.id}
           isCurrent={getIsCurrent(`${defaultSegment}${currentTab}`, item.href)}
+          isReplace={isReplace}
           {...item}
         />
       ))}

--- a/src/components/commons/TabMenuLinkUnderlined.tsx
+++ b/src/components/commons/TabMenuLinkUnderlined.tsx
@@ -6,16 +6,18 @@ interface ITabMenuLinkUnderlinedProps {
   title: string;
   count?: number;
   onClick?: () => void;
+  isReplace?: boolean;
 }
 
 export default function TabMenuLinkUnderlined(props: ITabMenuLinkUnderlinedProps) {
-  const { href, title, isCurrent, onClick } = props;
+  const { href, title, isCurrent, onClick, isReplace = false } = props;
   return (
     <Link
       className={`w-full flex justify-center items-center gap-1 py-3 border-b-2 text-sm font-medium leading-snug tracking-[-0.42px] ${
         isCurrent ? "border-b-3 text-main-500 border-main-500" : "border-gray-300"
       }`}
       href={href}
+      replace={isReplace}
       onClick={onClick}>
       <span>{title}</span>
       {props?.count && <span>{props.count}</span>}

--- a/src/components/domains/dashboard/Checkbox.tsx
+++ b/src/components/domains/dashboard/Checkbox.tsx
@@ -4,15 +4,28 @@ import { checkBlueOn } from "@/../public/icons/icons";
 export default function Checkbox({
   isChecked,
   type = "attendance",
+  isMyCheckItem,
 }: {
   isChecked: boolean;
   type?: "attendance" | "checkList";
+  isMyCheckItem: boolean;
 }) {
   return (
     <button
-      className={`w-5 h-5 rounded-full cursor-pointer ${!isChecked && "border-2 border-gray-400 bg-gray-200"}`}
-      disabled={type === "attendance" && isChecked}>
+      className={`w-5 h-5 rounded-full cursor-pointer disabled:cursor-not-allowed ${
+        !isChecked && "border-2 border-gray-400 bg-gray-200"
+      }`}
+      disabled={getIsDisabled(isMyCheckItem, type, isChecked)}>
       {isChecked && <Image src={checkBlueOn} alt="체크 아이콘" width={20} height={20} />}
     </button>
   );
+}
+
+function getIsDisabled(isMyCheckItem: boolean, type: string, isChecked: boolean) {
+  // 체크리스트는 내 체크리스트가 아닌 경우 무조건 disabled
+  if (isMyCheckItem === false) return true;
+  // 출석 체크는 체크한 뒤로 수정이 불가하므로 체크된 경우 무조건 disabled
+  if (type === "attendance" && isChecked) return true;
+  // 그 외에는 disabled 되어야 하는 경우 없음
+  else return false;
 }

--- a/src/components/domains/dashboard/ChecklistCard.tsx
+++ b/src/components/domains/dashboard/ChecklistCard.tsx
@@ -9,6 +9,8 @@ import { startOfDay } from "date-fns";
 import NoList from "../mystudy/NoList";
 import { useDashboardScheduleStore } from "@/store/dashboardScheduleStore";
 import { useState } from "react";
+import { useDashboardTeamStore } from "@/store/dashboardTeamStore";
+import { useUserStore } from "@/store/userStore";
 
 interface IChecklistCardProps {
   checkListData: TCheckListData[];
@@ -80,12 +82,17 @@ export default function ChecklistCard({ checkListData, studyId }: IChecklistCard
 
 function MyCheckItem({ checkItem, studyId }: { checkItem: any; studyId: any }) {
   const { content, isChecked, _id: checkItemId } = checkItem;
+  const { selectedUserId } = useDashboardTeamStore();
+  const { user } = useUserStore();
+  const userId = user ? user._id.toString() : null;
+  const isMyCheckItem = userId === selectedUserId;
+
   return (
     <li className="flex justify-between items-center py-2 rounded-sm">
       <form className="flex justify-start items-center gap-2 text-[0px]" action={toggleCheckItemAction}>
         <input type="hidden" name="studyId" value={studyId} />
         <input type="hidden" name="checkItemId" value={checkItemId} />
-        <Checkbox isChecked={isChecked} type="checkList" />
+        <Checkbox isChecked={isChecked} type="checkList" isMyCheckItem={isMyCheckItem} />
         <div className="text-gray-900 text-sm font-medium leading-tight">{content}</div>
       </form>
     </li>

--- a/src/components/domains/dashboard/ChecklistCard.tsx
+++ b/src/components/domains/dashboard/ChecklistCard.tsx
@@ -19,9 +19,9 @@ export default function ChecklistCard({ checkListData, studyId }: IChecklistCard
   const { currentDate } = useDashboardScheduleStore();
   const [newCheckItemContent, setNewCheckItemContent] = useState("");
 
-  if (!currentDate || !checkListData) return <></>;
+  if (!currentDate) return <></>;
 
-  const currentDateCheckListDataItem = checkListData.find(
+  const currentDateCheckListDataItem = checkListData?.find(
     (checkItem: any) => startOfDay(checkItem.date).getTime() === startOfDay(currentDate).getTime(),
   );
 

--- a/src/components/domains/dashboard/ChecklistCard.tsx
+++ b/src/components/domains/dashboard/ChecklistCard.tsx
@@ -85,7 +85,7 @@ function MyCheckItem({ checkItem, studyId }: { checkItem: any; studyId: any }) {
       <form className="flex justify-start items-center gap-2 text-[0px]" action={toggleCheckItemAction}>
         <input type="hidden" name="studyId" value={studyId} />
         <input type="hidden" name="checkItemId" value={checkItemId} />
-        <Checkbox isChecked={isChecked} />
+        <Checkbox isChecked={isChecked} type="checkList" />
         <div className="text-gray-900 text-sm font-medium leading-tight">{content}</div>
       </form>
     </li>

--- a/src/components/domains/dashboard/ProgressItem.tsx
+++ b/src/components/domains/dashboard/ProgressItem.tsx
@@ -1,22 +1,18 @@
 import Avatar from "@/components/commons/Avatar";
 import { ROLE_LIST, RoleType } from "@/constant/teamMemberInfo";
-import { getSession } from "@/lib/database/getSession";
 import { TProgressGaugeItem } from "@/types/dashboard";
 
 interface IProgressItem {
   item: TProgressGaugeItem;
   nickname: string;
   role: string;
-  isLeader: boolean;
+  isOwner: boolean;
+  isMe: boolean;
   profileImageUrl: string;
 }
 
 export default async function ProgressItem(props: IProgressItem) {
-  const { item, nickname, role, isLeader, profileImageUrl } = props;
-  const session = await getSession();
-  const userId = session?.user?.id;
-  const isMe = item.userId || "" === userId;
-  const isOwner = isLeader;
+  const { item, nickname, role, isOwner, isMe, profileImageUrl } = props;
 
   const progressWidth = `${item.data}%`;
 

--- a/src/components/domains/dashboard/StudyMemberAttendanceCard.tsx
+++ b/src/components/domains/dashboard/StudyMemberAttendanceCard.tsx
@@ -89,7 +89,7 @@ function getTodayAttendance(data: TAttendanceItem["data"]) {
   return data.find((item) => new Date(item.date).getDate() === today);
 }
 
-function getIsTodayInRange(startDate: Date, endDate: Date) {
+export function getIsTodayInRange(startDate: Date, endDate: Date) {
   const today = new Date();
   return today >= startDate && today <= endDate;
 }

--- a/src/components/domains/dashboard/StudyMemberAttendanceCard.tsx
+++ b/src/components/domains/dashboard/StudyMemberAttendanceCard.tsx
@@ -49,11 +49,12 @@ async function MemberItem(props: IMemberItem) {
   const { item, nickname } = props;
   const session = await getSession();
   const userId = session?.user?.id;
-  const isMe = item.userId || "" === userId;
+  const isMe = item.userId.toString() === userId;
   const { studyId, dashboardId } = useDashboardTeamStore.getState().dashboardInfo;
   if (!studyId || !dashboardId) return;
   const todayAttendance = getTodayAttendance(item.data);
   if (!todayAttendance) return;
+
   return (
     <li className="flex-shrink-0 flex flex-col items-center justify-end gap-2 w-[72px] py-2">
       {/* 
@@ -71,7 +72,7 @@ async function MemberItem(props: IMemberItem) {
           <input type="hidden" name="dashboardId" value={dashboardId} />
           <input type="hidden" name="studyId" value={studyId} />
           <input type="hidden" name="date" value={todayAttendance.date.toString()} />
-          <Checkbox isChecked={todayAttendance.isAttended} />
+          <Checkbox isChecked={todayAttendance.isAttended} isMyCheckItem={isMe} />
         </form>
         <div
           className={`text-center text-[14px] font-medium leading-tight tracking-[-0.28px] ${

--- a/src/components/domains/dashboard/StudyMemberProgressGaugeCard.tsx
+++ b/src/components/domains/dashboard/StudyMemberProgressGaugeCard.tsx
@@ -3,8 +3,9 @@ import DashboardCardLayout from "./DashboardCardLayout";
 import DashboardCardTitle from "../DashboardCardTitle";
 import { TProgressGaugeItem } from "@/types/dashboard";
 import { useDashboardTeamStore } from "@/store/dashboardTeamStore";
+import { getSession } from "@/lib/database/getSession";
 
-export default function StudyMemberProgressGaugeCard({
+export default async function StudyMemberProgressGaugeCard({
   list,
   teamMemberList,
 }: {
@@ -12,21 +13,26 @@ export default function StudyMemberProgressGaugeCard({
   teamMemberList: any[];
 }) {
   const { dashboardId, studyId } = useDashboardTeamStore.getState().dashboardInfo;
+  const session = await getSession();
+  const userId = session?.user?.id;
 
   return (
     <DashboardCardLayout>
       <DashboardCardTitle type="progressGauge" dashboardId={dashboardId} studyId={studyId} />
       <ul className="flex flex-col gap-3 max-h-[196px] overflow-y-scroll scrollbar-hide">
         {list.map((item) => {
-          const member = teamMemberList.find((member) => member.userId === item.userId.toString());
+          const itemUserId = item.userId.toString();
+          const member = teamMemberList.find((member) => member.userId === itemUserId);
+          const isMe = itemUserId === userId;
           return (
             <ProgressItem
               key={item.teamMemberId.toString()}
               item={item}
-              nickname={member?.nickname || ""}
-              role={member?.role || ""}
-              isLeader={member?.isOwner || false}
-              profileImageUrl={member?.profileImageUrl || ""}
+              nickname={member.nickname}
+              role={member.role}
+              isOwner={member.isOwner}
+              isMe={isMe}
+              profileImageUrl={member.profileImageUrl}
             />
           );
         })}

--- a/src/components/domains/dashboard/team/CheckItem.tsx
+++ b/src/components/domains/dashboard/team/CheckItem.tsx
@@ -2,6 +2,8 @@
 import { toggleCheckItemAction } from "@/lib/database/action/dashboard";
 import Checkbox from "../Checkbox";
 import { useParams } from "next/navigation";
+import { useDashboardTeamStore } from "@/store/dashboardTeamStore";
+import { useUserStore } from "@/store/userStore";
 
 interface ICheckItemProps {
   checkItem: any;
@@ -10,8 +12,12 @@ interface ICheckItemProps {
 export function CheckItem(props: ICheckItemProps) {
   const { checkItem } = props;
   const { _id: checkItemId, isChecked } = checkItem;
-
   const { id: studyId } = useParams();
+
+  const { selectedUserId } = useDashboardTeamStore();
+  const { user } = useUserStore();
+  const userId = user ? user._id.toString() : null;
+  const isMyCheckItem = userId === selectedUserId;
 
   if (!studyId) return <></>;
   return (
@@ -20,7 +26,7 @@ export function CheckItem(props: ICheckItemProps) {
         <form className="text-[0px]" action={toggleCheckItemAction}>
           <input type="hidden" name="checkItemId" value={checkItemId} />
           <input type="hidden" name="studyId" value={studyId} />
-          <Checkbox isChecked={isChecked} type="checkList" />
+          <Checkbox isChecked={isChecked} type="checkList" isMyCheckItem={isMyCheckItem} />
         </form>
         <div className="text-gray-900 text-sm font-medium leading-tight">{checkItem.content}</div>
       </div>

--- a/src/components/domains/dashboard/team/MemberItem.tsx
+++ b/src/components/domains/dashboard/team/MemberItem.tsx
@@ -23,12 +23,14 @@ export function MemberItem(props: IMemberItem) {
 
   return (
     <li className="flex-shrink-0 flex flex-col items-center justify-end gap-2 w-[72px]">
-      {!isMe && (
+      {/* @todo 추후 구현 _ 카톡 알림
+        * {!isMe && (
         <button className="w-[56px] h-[28px] pb-[5px] bg-[url('/icons/alert-bg-56.svg')] bg-center bg-[length:56px] bg-no-repeat text-center text-[#787878] text-[11px] font-medium leading-none">
           노크하기
         </button>
-      )}
-      <div
+      )} */}
+      <button
+        onClick={() => setSelectedUserId(memberUserId)}
         className={`flex flex-col justify-center items-center gap-1 w-full py-[10px] px-1 rounded border cursor-pointer ${
           isSelected ? "border-main-500 bg-main-100" : "border-transparent"
         }`}>
@@ -42,7 +44,7 @@ export function MemberItem(props: IMemberItem) {
         <div className="text-center text-stone-500 text-xs font-normal leading-none">
           {ROLE_LIST[role as keyof RoleType].name}
         </div>
-      </div>
+      </button>
     </li>
   );
 }

--- a/src/components/domains/dashboard/team/SelectedUserCheckList.tsx
+++ b/src/components/domains/dashboard/team/SelectedUserCheckList.tsx
@@ -8,7 +8,7 @@ import { CheckItem } from "./CheckItem";
 export default function SelectedUserCheckList({ allMemberTodayCheckList }: { allMemberTodayCheckList: any }) {
   const { selectedUserId, setSelectedUserId } = useDashboardTeamStore();
   const selectedUserCheckList = allMemberTodayCheckList.find((item: any) => item.userId === selectedUserId)?.data[0]
-    .contentList;
+    ?.contentList;
 
   useEffect(() => {
     if (!selectedUserId) setSelectedUserId(allMemberTodayCheckList[0].userId);

--- a/src/components/domains/dashboard/team/StudyMemberChecklistCard.tsx
+++ b/src/components/domains/dashboard/team/StudyMemberChecklistCard.tsx
@@ -24,7 +24,7 @@ export default async function StudyMemberChecklistCard({
       </DashboardCardTitle>
 
       {/* 팀 멤버 리스트 */}
-      <ul className="flex gap-4 justify-between overflow-y-scroll scrollbar-hide my-4">
+      <ul className="flex gap-4 overflow-y-scroll scrollbar-hide my-4">
         {teamMemberList?.map((member: any) => {
           const memberUserId = member.userId.toString();
           const isMe = memberUserId === userId;

--- a/src/components/domains/dashboard/team/StudyMemberChecklistCard.tsx
+++ b/src/components/domains/dashboard/team/StudyMemberChecklistCard.tsx
@@ -5,6 +5,9 @@ import { MemberItem } from "./MemberItem";
 import { getSession } from "@/lib/database/getSession";
 import { useDashboardTeamStore } from "@/store/dashboardTeamStore";
 import SelectedUserCheckList from "../team/SelectedUserCheckList";
+import { format } from "date-fns";
+import { getIsTodayInRange } from "../StudyMemberAttendanceCard";
+import NoList from "../../mystudy/NoList";
 
 export default async function StudyMemberChecklistCard({
   list,
@@ -15,25 +18,33 @@ export default async function StudyMemberChecklistCard({
 }) {
   const session = await getSession();
   const userId = session?.user?.id ?? "";
-  const { dashboardId, studyId } = useDashboardTeamStore.getState().dashboardInfo;
+  const { dashboardId, studyId, startDate, endDate } = useDashboardTeamStore.getState().dashboardInfo;
+  if (!startDate || !endDate) return <></>;
+  const isTodayInRange = getIsTodayInRange(new Date(startDate), new Date(endDate));
 
   return (
     <DashboardCardLayout>
       <DashboardCardTitle type="checkList" dashboardId={dashboardId} studyId={studyId}>
-        <span className="text-main-500 text-sm font-semibold leading-snug">{``}</span>
+        <span className="text-gray-600 text-sm font-medium leading-snug">{format(new Date(), "M월 d일")}</span>
       </DashboardCardTitle>
 
-      {/* 팀 멤버 리스트 */}
-      <ul className="flex gap-4 overflow-y-scroll scrollbar-hide my-4">
-        {teamMemberList?.map((member: any) => {
-          const memberUserId = member.userId.toString();
-          const isMe = memberUserId === userId;
-          return <MemberItem key={memberUserId} member={member} isMe={isMe} />;
-        })}
-      </ul>
+      {isTodayInRange ? (
+        <>
+          {/* 팀 멤버 리스트 */}
+          <ul className="flex gap-4 overflow-y-scroll scrollbar-hide my-4">
+            {teamMemberList?.map((member: any) => {
+              const memberUserId = member.userId.toString();
+              const isMe = memberUserId === userId;
+              return <MemberItem key={memberUserId} member={member} isMe={isMe} />;
+            })}
+          </ul>
 
-      {/* 선택된 유저의 오늘 체크리스트 */}
-      <SelectedUserCheckList allMemberTodayCheckList={list} />
+          {/* 선택된 유저의 오늘 체크리스트 */}
+          <SelectedUserCheckList allMemberTodayCheckList={list} />
+        </>
+      ) : (
+        <NoList>스터디 기간이 아닙니다.</NoList>
+      )}
     </DashboardCardLayout>
   );
 }

--- a/src/lib/database/action/dashboard.ts
+++ b/src/lib/database/action/dashboard.ts
@@ -86,6 +86,29 @@ export const fetchStudyMeetingAction = async (id: string) => {
   }
 };
 
+export const fetchIsMember = async (studyId: any) => {
+  const session = await getSession();
+  const userId = session?.user?.id;
+
+  if (!studyId || !userId) {
+    throw new Error("필수 정보가 없습니다.");
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.LOCAL_URL}/api/dashboard/checklist?studyId=${studyId}&userId=${userId}`,
+    );
+    const myCheckList = await response.json();
+
+    revalidatePath(`/study/${studyId}/dashboard/me`);
+
+    return myCheckList;
+  } catch (error) {
+    console.error("Error fetching", error);
+    throw error;
+  }
+};
+
 export const fetchMyCheckListAction = async (studyId: any) => {
   const session = await getSession();
   const userId = session?.user?.id;
@@ -104,7 +127,7 @@ export const fetchMyCheckListAction = async (studyId: any) => {
 
     return myCheckList;
   } catch (error) {
-    console.error("Error fetching study", error);
+    console.error("Error fetching", error);
     throw error;
   }
 };

--- a/src/utils/generateMeetingList.ts
+++ b/src/utils/generateMeetingList.ts
@@ -50,7 +50,7 @@ export type TMeetingItem = { title: string; where: string; date: Date };
 export type TUpcomingMeetingList = TMeetingItem[];
 
 export function generateUpcomingMeetingList(props: IGenerateUpcomingMeetingListProps): TUpcomingMeetingList {
-  const { startDate, endDate, title, where, day, time } = props;
+  const { endDate, title, where, day, time } = props;
   const meetingDayOfWeek = dayMap[day];
   const meetingTime = timeMap[time][0];
   const meetingMinutes = timeMap[time][1];
@@ -61,12 +61,11 @@ export function generateUpcomingMeetingList(props: IGenerateUpcomingMeetingListP
   let meetingList = [];
   let current = today;
 
-  while (current >= startDate && current >= today && current <= twoWeekFromToday && current <= endDate) {
+  while (current >= today && current <= twoWeekFromToday && current <= endDate) {
     // 1. 오늘 이후
     // 2. 2주 이내
-    // 3. startDate 이후
-    // 4. endDate 이내
-    // 5. current의 요일 === 미팅 요일
+    // 3. endDate 이내
+    // 4. current의 요일 === 미팅 요일
     const targetDayOfWeek = getDay(current);
 
     if (targetDayOfWeek === meetingDayOfWeek) {


### PR DESCRIPTION
## 작업 주제

- [x] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정

## 스크린샷
https://github.com/user-attachments/assets/98c8bb11-7433-4455-b575-8be978aa4993


## 구현 사항 설명
- [x] 다가오는 미팅 계산식 수정 (오늘이 startDate 보다 이후인지 조건 제거)
- [x] 내가 관련된 모든 스터디 조회 로직 수정
- [x] 내가 참여하는 모든 스터디 조회 로직 수정
- [x] 팀 탭 체크리스트 없을 경우 에러 디버깅
- [x] 개인 탭 체크리스트 없을 경우 타입 에러 디버깅
- [x] 개인 탭 체크리스트 없을 경우 카드 노출되도록 (추가 가능하도록) 수정
- [x] 개인 탭 체크리스트 토글 가능하도록 type prop 추가
- [x] 개인 탭 멤버인지 체크 API 구현 및 멤버 / 비멤버 UI 조건부 렌더링
- [x] 팀 탭 팀원이 있을 경우 선택 유저 변경 기능 추가
- [x] 팀 탭 개설자에게만 대시보드 기능 활성화 버튼 보이도록 수정
- [x] 대시보드 페이지에 GNB 추가
- [x] 체크리스트 오늘 날짜 노출
- [x] 체크리스트 오늘 날짜가 스터디 기간이 아닌 경우 UI 추가
- [x] 체크리스트 본인만 클릭할 수 있도록 제한
- [x] 진척도 유저별 상태 파악 로직 수정 
- [x] 탭 페이지 간 이동 시 isReplace 옵션 추가 및 일부 페이지 옵션 적용
close #128