### PR TITLE
Feat: 게시글 삭제, 게시글 댓글 작성/리스트/삭제 api 구현 및 게시글 리스트 api 리팩토링 (게시판 별로 분리 후 페이지네이션,무한스크롤 추가)

### DIFF
--- a/src/app/api/dashboard-post/[postId]/comment/[commentId]/route.ts
+++ b/src/app/api/dashboard-post/[postId]/comment/[commentId]/route.ts
@@ -1,0 +1,42 @@
+import connectDB from "@/lib/database/db";
+import { DashboardComment } from "@/schema/dashboardCommentSchema";
+import { DashboardPost } from "@/schema/dashboardPostSchema";
+import { User } from "@/schema/userSchema";
+
+export async function DELETE(request: Request, { params }: { params: { commentId: string } }) {
+  const commentId = params.commentId;
+  if (!commentId) {
+    return Response.json({ error: "comment Id 가 필요합니다." }, { status: 400 });
+  }
+
+  const token = request.headers.get("Authorization");
+  const userId = token?.split(" ")[1];
+  if (!userId) {
+    return Response.json({ error: "user id 가 필요합니다." }, { status: 400 });
+  }
+  await connectDB();
+  try {
+    const comment = await DashboardComment.findById(commentId);
+    if (!comment) {
+      return Response.json({ message: "댓글이 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const user = await User.findById(userId);
+    if (!user) {
+      return Response.json({ message: "해당 유저가 존재하지 않습니다." }, { status: 404 });
+    }
+
+    if (comment.userId.toString() !== userId) {
+      return Response.json({ message: "권한이 없습니다." }, { status: 403 });
+    }
+    await DashboardComment.findByIdAndDelete(commentId);
+
+    return Response.json({ message: "해당 댓글이 삭제되었습니다." }, { status: 200 });
+  } catch (error: any) {
+    if (error.name === "CastError") {
+      return Response.json({ message: "댓글이 존재하지 않습니다." }, { status: 404 });
+    } else {
+      return Response.json({ message: error.name }, { status: 500 });
+    }
+  }
+}

--- a/src/app/api/dashboard-post/[postId]/comment/route.ts
+++ b/src/app/api/dashboard-post/[postId]/comment/route.ts
@@ -4,9 +4,9 @@ import { DashboardPost } from "@/schema/dashboardPostSchema";
 import { Study } from "@/schema/studySchema";
 import { TeamMembers } from "@/schema/teamMemberSchema";
 import { User } from "@/schema/userSchema";
+import { TPostComment } from "@/types/api/dashboardPost";
 
 export async function POST(request: Request, { params }: { params: { postId: string } }) {
-  await connectDB();
   const postId = params.postId;
   const token = request.headers.get("Authorization");
   const userId = token?.split(" ")[1];
@@ -25,6 +25,7 @@ export async function POST(request: Request, { params }: { params: { postId: str
   }
 
   try {
+    await connectDB();
     const isUserExisted = await User.findById(userId);
     if (!isUserExisted) {
       return Response.json({ message: "해당 유저가 존재하지 않습니다." }, { status: 410 });
@@ -55,18 +56,81 @@ export async function POST(request: Request, { params }: { params: { postId: str
     if (!post) {
       return Response.json({ message: "해당 게시글이 존재하지 않습니다." }, { status: 404 });
     }
+    const userInTeamMember = teamMembers.members.find((member: any) => {
+      return member.userId.toString() === userId;
+    });
 
     const newComment = {
       studyId,
       postId,
       userId,
+      role: userInTeamMember.role,
       content,
     };
 
     const newPostResult = await DashboardComment.create(newComment);
 
     return Response.json(newPostResult, { status: 200 });
-  } catch (error: any) {
+  } catch (error) {
+    console.error("error dashboard-post", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request, { params }: { params: { postId: string } }) {
+  const postId = params.postId;
+  const token = request.headers.get("Authorization");
+  const userId = token?.split(" ")[1];
+
+  const { searchParams } = new URL(request.url);
+  const sortBy = searchParams.get("sortBy") || "OLDEST";
+
+  let sortOption: { [key: string]: any } = {};
+
+  if (sortBy === "OLDEST") {
+    sortOption = { createdAt: 1 };
+  } else if (sortBy === "LATEST") {
+    sortOption = { createdAt: -1 };
+  }
+
+  try {
+    await connectDB();
+    const post = await DashboardPost.findById(postId);
+
+    if (!post) {
+      return Response.json({ message: "해당 게시글이 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const commentListData = await DashboardComment.find({ postId }).sort(sortOption);
+
+    let commentList: TPostComment[] = [];
+
+    if (commentListData) {
+      commentList = await Promise.all(
+        commentListData.map(async (comment) => {
+          const { _id, userId: commentUserId, role, content, postId, studyId, createdAt, updatedAt } = comment;
+          const user = await User.findById(commentUserId);
+          const isMine = userId === commentUserId.toString();
+
+          return {
+            id: _id,
+            postId,
+            studyId,
+            userId: commentUserId,
+            role,
+            nickname: user.nickname,
+            profileImageUrl: user.profileImageUrl,
+            content,
+            isMine,
+            createdAt,
+            updatedAt,
+          };
+        }),
+      );
+    }
+
+    return Response.json(commentList, { status: 200 });
+  } catch (error) {
     console.error("error dashboard-post", error);
     return Response.json({ error }, { status: 500 });
   }

--- a/src/app/api/dashboard-post/[postId]/comment/route.ts
+++ b/src/app/api/dashboard-post/[postId]/comment/route.ts
@@ -1,0 +1,73 @@
+import connectDB from "@/lib/database/db";
+import { DashboardComment } from "@/schema/dashboardCommentSchema";
+import { DashboardPost } from "@/schema/dashboardPostSchema";
+import { Study } from "@/schema/studySchema";
+import { TeamMembers } from "@/schema/teamMemberSchema";
+import { User } from "@/schema/userSchema";
+
+export async function POST(request: Request, { params }: { params: { postId: string } }) {
+  await connectDB();
+  const postId = params.postId;
+  const token = request.headers.get("Authorization");
+  const userId = token?.split(" ")[1];
+  if (!userId) {
+    return Response.json({ error: "user id 가 필요합니다." }, { status: 400 });
+  }
+
+  const { studyId, content } = await request.json();
+
+  if (!studyId) {
+    return Response.json({ error: "studyId 가 필요합니다." }, { status: 400 });
+  }
+
+  if (!content) {
+    return Response.json({ error: "content가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    const isUserExisted = await User.findById(userId);
+    if (!isUserExisted) {
+      return Response.json({ message: "해당 유저가 존재하지 않습니다." }, { status: 410 });
+    }
+
+    const study = await Study.findById(studyId);
+    if (!study) {
+      return Response.json({ message: "해당 스터디가 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const studyData = await Study.findById(studyId);
+
+    if (studyData.status !== "PROGRESS") {
+      return Response.json({ message: "진행중인 스터디가 아닙니다." }, { status: 404 });
+    }
+
+    const teamMembers = await TeamMembers.findOne({ studyId });
+
+    const isTeamMember = teamMembers.members.some(
+      (member: any) => member.status === "ACCEPTED" && member.userId.toString() === userId,
+    );
+
+    if (!isTeamMember) {
+      return Response.json({ message: "스터디 멤버가 아닙니다." }, { status: 404 });
+    }
+    const post = await DashboardPost.findById(postId);
+
+    if (!post) {
+      return Response.json({ message: "해당 게시글이 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const newComment = {
+      studyId,
+      postId,
+      userId,
+      content,
+    };
+
+    const newPostResult = await DashboardComment.create(newComment);
+
+    return Response.json(newPostResult, { status: 200 });
+  } catch (error: any) {
+    console.error("error dashboard-post", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/src/app/api/dashboard-post/[postId]/route.ts
+++ b/src/app/api/dashboard-post/[postId]/route.ts
@@ -5,17 +5,13 @@ import { User } from "@/schema/userSchema";
 
 export async function DELETE(request: Request, { params }: { params: { postId: string } }) {
   const postId = params.postId;
-  if (!postId) {
-    return Response.json({ error: "post id 가 필요합니다." }, { status: 400 });
-  }
-
   const token = request.headers.get("Authorization");
   const userId = token?.split(" ")[1];
   if (!userId) {
     return Response.json({ error: "user id 가 필요합니다." }, { status: 400 });
   }
-  await connectDB();
   try {
+    await connectDB();
     const post = await DashboardPost.findById(postId);
     if (!post) {
       return Response.json({ message: "게시글이 존재하지 않습니다." }, { status: 404 });

--- a/src/app/api/dashboard-post/[postId]/route.ts
+++ b/src/app/api/dashboard-post/[postId]/route.ts
@@ -1,0 +1,41 @@
+import connectDB from "@/lib/database/db";
+import { DashboardPost } from "@/schema/dashboardPostSchema";
+import { User } from "@/schema/userSchema";
+
+export async function DELETE(request: Request, { params }: { params: { postId: string } }) {
+  const postId = params.postId;
+  if (!postId) {
+    return Response.json({ error: "post id 가 필요합니다." }, { status: 400 });
+  }
+
+  const token = request.headers.get("Authorization");
+  const userId = token?.split(" ")[1];
+  if (!userId) {
+    return Response.json({ error: "user id 가 필요합니다." }, { status: 400 });
+  }
+  await connectDB();
+  try {
+    const post = await DashboardPost.findById(postId);
+    if (!post) {
+      return Response.json({ message: "게시글이 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const user = await User.findById(userId);
+    if (!user) {
+      return Response.json({ message: "해당 유저가 존재하지 않습니다." }, { status: 404 });
+    }
+
+    if (post.writerId.toString() !== userId) {
+      return Response.json({ message: "권한이 없습니다." }, { status: 403 });
+    }
+    await DashboardPost.findByIdAndDelete(postId);
+
+    return Response.json({ message: "해당 게시글이 삭제되었습니다." }, { status: 200 });
+  } catch (error: any) {
+    if (error.name === "CastError") {
+      return Response.json({ message: "게시글이 존재하지 않습니다." }, { status: 404 });
+    } else {
+      return Response.json({ message: error.name }, { status: 500 });
+    }
+  }
+}

--- a/src/app/api/dashboard-post/[postId]/route.ts
+++ b/src/app/api/dashboard-post/[postId]/route.ts
@@ -1,4 +1,5 @@
 import connectDB from "@/lib/database/db";
+import { DashboardComment } from "@/schema/dashboardCommentSchema";
 import { DashboardPost } from "@/schema/dashboardPostSchema";
 import { User } from "@/schema/userSchema";
 
@@ -28,6 +29,10 @@ export async function DELETE(request: Request, { params }: { params: { postId: s
     if (post.writerId.toString() !== userId) {
       return Response.json({ message: "권한이 없습니다." }, { status: 403 });
     }
+
+    const commentListData = await DashboardComment.find({ postId });
+    await Promise.all(commentListData.map(async (comment) => await DashboardComment.findByIdAndDelete(comment._id)));
+
     await DashboardPost.findByIdAndDelete(postId);
 
     return Response.json({ message: "해당 게시글이 삭제되었습니다." }, { status: 200 });

--- a/src/app/api/dashboard-post/list/free/route.ts
+++ b/src/app/api/dashboard-post/list/free/route.ts
@@ -1,0 +1,77 @@
+import connectDB from "@/lib/database/db";
+import { DashboardComment } from "@/schema/dashboardCommentSchema";
+import { DashboardPost } from "@/schema/dashboardPostSchema";
+import { Study } from "@/schema/studySchema";
+import { TeamMembers } from "@/schema/teamMemberSchema";
+import { User } from "@/schema/userSchema";
+import { TFreePost } from "@/types/api/dashboardPost";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const studyId = searchParams.get("studyId");
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const pageSize = parseInt(searchParams.get("pageSize") || "4", 10);
+
+  try {
+    await connectDB();
+    const study = await Study.findById(studyId);
+    if (!study) {
+      return Response.json({ message: "해당 스터디가 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const studyData = await Study.findById(studyId);
+
+    if (studyData.status !== "PROGRESS") {
+      return Response.json({ message: "진행중인 스터디가 아닙니다." }, { status: 404 });
+    }
+
+    const freePostListData = await DashboardPost.find({ studyId, postType: "free" })
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * pageSize)
+      .limit(pageSize);
+
+    const teamMembers = await TeamMembers.findOne({ studyId });
+
+    let freePostList: TFreePost[] = [];
+
+    if (freePostListData) {
+      freePostList = await Promise.all(
+        freePostListData.map(async (post: any) => {
+          const { _id, studyId, writerId, title, content, imageUrl, postType, createdAt, updatedAt } = post;
+          const user = await User.findById(writerId);
+          const writerInTeamMember = teamMembers.members.find((member: any) => {
+            return member.userId.toString() === writerId.toString();
+          });
+          const commentList = await DashboardComment.find({ postId: _id });
+          return {
+            _id: _id.toString(),
+            studyId,
+            writer: {
+              writerId,
+              role: writerInTeamMember.role,
+              nickname: user.nickname,
+              profileImageUrl: user.profileImageUrl,
+            },
+            title,
+            content,
+            imageUrl,
+            postType,
+            commentCount: commentList.length,
+            createdAt,
+            updatedAt,
+          };
+        }),
+      );
+    }
+
+    const totalFreePost = await DashboardPost.find({ studyId, postType: "free" }).sort({ createdAt: -1 });
+    const totalFreeCount = totalFreePost.length;
+    const totalPages = Math.ceil(totalFreeCount / pageSize);
+    const hasMorePage = totalPages > page;
+
+    return Response.json({ freePostList, totalPages, currentPage: page, pageSize, hasMorePage }, { status: 200 });
+  } catch (error) {
+    console.error("error dashboard free post:", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/src/app/api/dashboard-post/list/notice/route.ts
+++ b/src/app/api/dashboard-post/list/notice/route.ts
@@ -1,0 +1,75 @@
+import connectDB from "@/lib/database/db";
+import { DashboardPost } from "@/schema/dashboardPostSchema";
+import { Study } from "@/schema/studySchema";
+import { TeamMembers } from "@/schema/teamMemberSchema";
+import { User } from "@/schema/userSchema";
+import { TNoticePost } from "@/types/api/dashboardPost";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const studyId = searchParams.get("studyId");
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const pageSize = parseInt(searchParams.get("pageSize") || "4", 10);
+
+  try {
+    await connectDB();
+    const study = await Study.findById(studyId);
+    if (!study) {
+      return Response.json({ message: "해당 스터디가 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const studyData = await Study.findById(studyId);
+
+    if (studyData.status !== "PROGRESS") {
+      return Response.json({ message: "진행중인 스터디가 아닙니다." }, { status: 404 });
+    }
+
+    const noticePostListData = await DashboardPost.find({ studyId, postType: "notice" })
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * pageSize)
+      .limit(pageSize);
+
+    const teamMembers = await TeamMembers.findOne({ studyId });
+
+    let noticePostList: TNoticePost[] = [];
+
+    if (noticePostListData) {
+      noticePostList = await Promise.all(
+        noticePostListData.map(async (post: any) => {
+          const { _id, studyId, writerId, title, content, postType, createdAt, updatedAt, isImportant } = post;
+          const user = await User.findById(writerId);
+          const writerInTeamMember = teamMembers.members.find((member: any) => {
+            return member.userId.toString() === writerId.toString();
+          });
+
+          return {
+            _id: _id.toString(),
+            studyId,
+            writer: {
+              writerId,
+              role: writerInTeamMember.role,
+              nickname: user.nickname,
+              profileImageUrl: user.profileImageUrl,
+            },
+            title,
+            content,
+            postType,
+            isImportant,
+            createdAt,
+            updatedAt,
+          };
+        }),
+      );
+    }
+
+    const totalNoticePost = await DashboardPost.find({ studyId, postType: "notice" }).sort({ createdAt: -1 });
+    const totalNoticeCount = totalNoticePost.length;
+    const totalPages = Math.ceil(totalNoticeCount / pageSize);
+    const hasMorePage = totalPages > page;
+
+    return Response.json({ noticePostList, totalPages, currentPage: page, pageSize, hasMorePage }, { status: 200 });
+  } catch (error) {
+    console.error("error dashboard notice post:", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/src/app/api/dashboard-post/list/task/route.ts
+++ b/src/app/api/dashboard-post/list/task/route.ts
@@ -1,0 +1,78 @@
+import connectDB from "@/lib/database/db";
+import { DashboardComment } from "@/schema/dashboardCommentSchema";
+import { DashboardPost } from "@/schema/dashboardPostSchema";
+import { Study } from "@/schema/studySchema";
+import { TeamMembers } from "@/schema/teamMemberSchema";
+import { User } from "@/schema/userSchema";
+import { TTaskPost } from "@/types/api/dashboardPost";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const studyId = searchParams.get("studyId");
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const pageSize = parseInt(searchParams.get("pageSize") || "4", 10);
+
+  await connectDB();
+
+  try {
+    const study = await Study.findById(studyId);
+    if (!study) {
+      return Response.json({ message: "해당 스터디가 존재하지 않습니다." }, { status: 404 });
+    }
+
+    const studyData = await Study.findById(studyId);
+
+    if (studyData.status !== "PROGRESS") {
+      return Response.json({ message: "진행중인 스터디가 아닙니다." }, { status: 404 });
+    }
+
+    const taskPostListData = await DashboardPost.find({ studyId, postType: "task" })
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * pageSize)
+      .limit(pageSize);
+
+    const teamMembers = await TeamMembers.findOne({ studyId });
+
+    let taskPostList: TTaskPost[] = [];
+
+    if (taskPostListData) {
+      taskPostList = await Promise.all(
+        taskPostListData.map(async (post: any) => {
+          const { _id, studyId, writerId, title, content, imageUrl, postType, createdAt, updatedAt } = post;
+          const user = await User.findById(writerId);
+          const writerInTeamMember = teamMembers.members.find((member: any) => {
+            return member.userId.toString() === writerId.toString();
+          });
+
+          const commentList = await DashboardComment.find({ postId: _id });
+
+          return {
+            _id: _id.toString(),
+            studyId,
+            writer: {
+              writerId,
+              role: writerInTeamMember.role,
+              nickname: user.nickname,
+              profileImageUrl: user.profileImageUrl,
+            },
+            title,
+            content,
+            imageUrl,
+            postType,
+            commentCount: commentList.length,
+            createdAt,
+            updatedAt,
+          };
+        }),
+      );
+    }
+    const totalTaskPost = await DashboardPost.find({ studyId, postType: "task" }).sort({ createdAt: -1 });
+    const totalTaskCount = totalTaskPost.length;
+    const totalPages = Math.ceil(totalTaskCount / pageSize);
+    const hasMorePage = totalPages > page;
+    return Response.json({ taskPostList, totalPages, currentPage: page, pageSize, hasMorePage }, { status: 200 });
+  } catch (error) {
+    console.error("error dashboard task post:", error);
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/src/app/api/dashboard-post/route.ts
+++ b/src/app/api/dashboard-post/route.ts
@@ -79,7 +79,6 @@ export async function POST(request: Request) {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const studyId = searchParams.get("studyId");
-  // const type = searchParams.get("type");
 
   await connectDB();
 

--- a/src/app/api/dashboard-post/route.ts
+++ b/src/app/api/dashboard-post/route.ts
@@ -17,18 +17,18 @@ export async function POST(request: Request) {
   const { studyId, title, content, postType, isImportant, imageUrl } = await request.json();
 
   if (!studyId) {
-    Response.json({ error: "studyId 가 필요합니다." }, { status: 400 });
+    return Response.json({ error: "studyId 가 필요합니다." }, { status: 400 });
   }
   if (!title) {
-    Response.json({ error: "title이 필요합니다." }, { status: 400 });
+    return Response.json({ error: "title이 필요합니다." }, { status: 400 });
   }
 
   if (!content) {
-    Response.json({ error: "content가 필요합니다." }, { status: 400 });
+    return Response.json({ error: "content가 필요합니다." }, { status: 400 });
   }
 
   if (!postType) {
-    Response.json({ error: "postType이 필요합니다." }, { status: 400 });
+    return Response.json({ error: "postType이 필요합니다." }, { status: 400 });
   }
 
   try {

--- a/src/app/api/dashboard-post/route.ts
+++ b/src/app/api/dashboard-post/route.ts
@@ -1,4 +1,5 @@
 import connectDB from "@/lib/database/db";
+import { DashboardComment } from "@/schema/dashboardCommentSchema";
 import { DashboardPost } from "@/schema/dashboardPostSchema";
 import { Study } from "@/schema/studySchema";
 import { TeamMembers } from "@/schema/teamMemberSchema";
@@ -118,7 +119,8 @@ export async function GET(request: Request) {
           const writerInTeamMember = teamMembers.members.find((member: any) => {
             return member.userId.toString() === writerId.toString();
           });
-          //commentCount 추가
+
+          const commentList = await DashboardComment.find({ postId: _id });
 
           return {
             _id: _id.toString(),
@@ -133,7 +135,7 @@ export async function GET(request: Request) {
             content,
             imageUrl,
             postType,
-            commentCount: 0,
+            commentCount: commentList.length,
             createdAt,
             updatedAt,
           };
@@ -150,9 +152,7 @@ export async function GET(request: Request) {
           const writerInTeamMember = teamMembers.members.find((member: any) => {
             return member.userId.toString() === writerId.toString();
           });
-
-          //commentCount 추가
-
+          const commentList = await DashboardComment.find({ postId: _id });
           return {
             _id: _id.toString(),
             studyId,
@@ -166,7 +166,7 @@ export async function GET(request: Request) {
             content,
             imageUrl,
             postType,
-            commentCount: 0,
+            commentCount: commentList.length,
             createdAt,
             updatedAt,
           };

--- a/src/app/api/study/[id]/apply-cancel/route.ts
+++ b/src/app/api/study/[id]/apply-cancel/route.ts
@@ -22,6 +22,11 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     if (!study) {
       return Response.json({ message: "스터디가 존재하지 않습니다." }, { status: 404 });
     }
+
+    if (study.status !== "RECRUIT_START") {
+      return Response.json({ message: "스터디가 모집중일때 취소/탈퇴가 가능합니다." }, { status: 404 });
+    }
+
     const user = await User.findById(userId);
     if (!user) {
       return Response.json({ message: "유저가 존재하지 않습니다." }, { status: 404 });

--- a/src/app/recruit/success/[id]/page.tsx
+++ b/src/app/recruit/success/[id]/page.tsx
@@ -1,7 +1,10 @@
+"use client";
 import Button from "@/components/commons/Button";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function Success({ params }: { params: { id: string } }) {
+  const router = useRouter();
+
   return (
     <div className="w-full h-dvh px-[22px] py-[16px] flex-col inline-flex">
       <div className="flex-col inline-flex justify-center items-center gap-[13px] flex-1">
@@ -14,11 +17,12 @@ export default function Success({ params }: { params: { id: string } }) {
           </p>
         </div>
       </div>
-      <Link href={`/study/${params.id}`}>
-        <Button varient="filled" addStyle="w-full h-12 bg-blue-500 text-white font-semibold rounded">
-          확인
-        </Button>
-      </Link>
+      <Button
+        onClick={() => router.replace(`/study/${params.id}`)}
+        varient="filled"
+        addStyle="w-full h-12 bg-blue-500 text-white font-semibold rounded">
+        확인
+      </Button>
     </div>
   );
 }

--- a/src/schema/dashboardCommentSchema.ts
+++ b/src/schema/dashboardCommentSchema.ts
@@ -5,6 +5,7 @@ const dashboardCommentSchema = new mongoose.Schema(
     studyId: { type: mongoose.Schema.Types.ObjectId, ref: "Study", required: true },
     postId: { type: mongoose.Schema.Types.ObjectId, ref: "DashboardPost", required: true },
     userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    role: { type: String, required: true },
     content: { type: String, required: true },
   },
   { timestamps: true },

--- a/src/types/api/dashboardPost.ts
+++ b/src/types/api/dashboardPost.ts
@@ -13,3 +13,17 @@ export type TTaskPost = {
 };
 
 export type TFreePost = TTaskPost;
+
+export type TPostComment = {
+  id: string;
+  postId: string;
+  studyId: string;
+  userId: string;
+  role: string;
+  nickname: string;
+  profileImageUrl: string;
+  content: string;
+  isMine: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/types/api/dashboardPost.ts
+++ b/src/types/api/dashboardPost.ts
@@ -6,13 +6,24 @@ export type TTaskPost = {
   content: string;
   imageUrl: string | null;
   postType?: "notice" | "task" | "free";
-  isImportant?: boolean;
   commentCount: number;
   createdAt: Date;
   updatedAt?: Date;
 };
 
 export type TFreePost = TTaskPost;
+
+export type TNoticePost = {
+  _id: string;
+  studyId?: string;
+  writer: { writerId: string; role: string; nickname: string; profileImageUrl: string };
+  title: string;
+  content: string;
+  postType?: "notice" | "task" | "free";
+  isImportant?: boolean;
+  createdAt: Date;
+  updatedAt?: Date;
+};
 
 export type TPostComment = {
   id: string;


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정

## 스크린샷

![image](이미지url)

## 구현 사항 설명

1. 게시글 삭제 api 구현 
2. 게시글 댓글 작성, 리스트 가져오기, 삭제 api 구현  
3. 기존에 있는 게시글 리스트 api 를 무한스크롤 페이지네이션 때문에.... 게시판 별로 분리해서 구현했습니다.
-> 변경된걸로 반영해서 수정필요 / 변경된거 반영후 기존 게시글 리스트 api 삭제 예정 

1,2,3 번은 노션 api명세서 참고해주세요


- 추가 작업 
4. 스터디 지원취소. 팀탈퇴 api 스터디 모집중일때 할수있도록 처리
5. 스터디 모집 성공시 페이지 이동 push에서 router로 수정 